### PR TITLE
update account_id retrieve

### DIFF
--- a/aws/kms/README.md
+++ b/aws/kms/README.md
@@ -59,7 +59,6 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_alias_name"></a> [alias\_name](#input\_alias\_name) | A list of aliases to create. Note - due to the use of `toset()`, values must be static strings and not computed values. | `list(string)` | `[]` | no |
-| <a name="input_aws_account_id"></a> [aws\_account\_id](#input\_aws\_account\_id) | The ID of AWS account | `string` | n/a | yes |
 | <a name="input_custom_key_store_id"></a> [custom\_key\_store\_id](#input\_custom\_key\_store\_id) | ID of the KMS Custom Key Store where the key will be stored instead of KMS (eg CloudHSM). | `string` | `null` | no |
 | <a name="input_customer_master_key_spec"></a> [customer\_master\_key\_spec](#input\_customer\_master\_key\_spec) | Specifies whether the key contains a symmetric key or an asymmetric key pair and the encryption algorithms or signing algorithms that the key supports. Valid values: SYMMETRIC\_DEFAULT, RSA\_2048, RSA\_3072, RSA\_4096, HMAC\_256, ECC\_NIST\_P256, ECC\_NIST\_P384, ECC\_NIST\_P521, or ECC\_SECG\_P256K1. | `string` | `"SYMMETRIC_DEFAULT"` | no |
 | <a name="input_deletion_window_in_days"></a> [deletion\_window\_in\_days](#input\_deletion\_window\_in\_days) | The waiting period, specified in number of days. | `number` | `7` | no |

--- a/aws/kms/data.tf
+++ b/aws/kms/data.tf
@@ -1,0 +1,1 @@
+data "aws_caller_identity" "current" {}

--- a/aws/kms/iam.tf
+++ b/aws/kms/iam.tf
@@ -7,7 +7,7 @@ data "aws_iam_policy_document" "this" {
     effect = "Allow"
     principals {
       type        = "AWS"
-      identifiers = ["arn:aws:iam::${var.aws_account_id}:root"]
+      identifiers = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"]
     }
     actions   = ["kms:*"]
     resources = ["*"]

--- a/aws/kms/variables.tf
+++ b/aws/kms/variables.tf
@@ -57,8 +57,3 @@ variable "principal_roles" {
   type        = list(string)
   default     = null
 }
-
-variable "aws_account_id" {
-  description = "The ID of AWS account."
-  type        = string
-}


### PR DESCRIPTION
## Summary
Use `aws_caller_identity` to get `aws_account_id` instead of using a input variable
<!--- Add some bells and whistles for PR template. --->

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply --->
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 🕷 Bug fix (non-breaking change which fixes an issue)
- [ ] 👏 Performance optimization (non-breaking change which addresses a performance issue)
- [x] 🛠 Refactor (non-breaking change which does not change existing behavior or add new functionality)
- [ ] 📗 Library update (non-breaking change that will update one or more libraries to newer versions)
- [ ] 📝 Documentation (non-breaking change that doesn't change code behavior, can skip testing)
- [ ] ✅ Test (non-breaking change related to testing)
- [ ] 🔒 Security awareness (changes that effect permission scope, security scenarios)

## Test Plan
<!--- Please input steps on how to test this PR, including evidence in the form of captured images or videos. If this is not necessary, provide the reason why. --->

## Related Issues
https://www.notion.so/c0x12c/Stratos-15701fb05bf1803480e1d90a81eae2ab?pvs=4
<!--- Add a reference section for management tickets, and relevant conversations. --->
