### PR TITLE
Update AWS eks-cluster module

### DIFF
--- a/aws/eks-cluster/CHANGELOG.md
+++ b/aws/eks-cluster/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
-## [0.1.18]() (2024-12-23)
+## [0.1.19]() (2024-12-23)
 ### Features
 * Add output datadog_agent_cluster_role_name to root module and remove default value of datadog_agent_cluster_role_name in submodule
 * Change assume policy of `eks-node-cluster` from `eks.amazonaws.com` to `ec2.amazonaws.com`

--- a/aws/eks-cluster/CHANGELOG.md
+++ b/aws/eks-cluster/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [0.1.18]() (2024-12-23)
+### Features
+* Add output datadog_agent_cluster_role_name to root module and remove default value of datadog_agent_cluster_role_name in submodule
+* Change assume policy of `eks-node-cluster` from `eks.amazonaws.com` to `ec2.amazonaws.com`
+
 ## [0.1.4]() (2024-12-05)
 ### Features
 * Update terraform version constraint from `~> 1.9.8` to `>= 1.9.8` 

--- a/aws/eks-cluster/README.md
+++ b/aws/eks-cluster/README.md
@@ -141,6 +141,7 @@ module "eks" {
 | <a name="input_cluster_version"></a> [cluster\_version](#input\_cluster\_version) | The Kubernetes version for creating the cluster. | `string` | `"1.31"` | no |
 | <a name="input_create_fargate_profile"></a> [create\_fargate\_profile](#input\_create\_fargate\_profile) | Specify whether creaing the Fargate profile for running pods. | `bool` | `false` | no |
 | <a name="input_custom_namespaces"></a> [custom\_namespaces](#input\_custom\_namespaces) | Custom namespaces to be created during initialization | `list(string)` | `[]` | no |
+| <a name="input_datadog_agent_cluster_role_name"></a> [datadog\_agent\_cluster\_role\_name](#input\_datadog\_agent\_cluster\_role\_name) | Name of the ClusterRole to create in order to configure Datadog Agents | `string` | `"datadog-agent"` | no |
 | <a name="input_default_service_account"></a> [default\_service\_account](#input\_default\_service\_account) | Default service account name for binding with Datadog | `string` | `"default"` | no |
 | <a name="input_efs_backup_policy_status"></a> [efs\_backup\_policy\_status](#input\_efs\_backup\_policy\_status) | Enable/disable backup for EFS Filesystem.  Value should be ENABLE/DISABLED.  Defaults to DISABLED | `string` | `"DISABLED"` | no |
 | <a name="input_efs_lifecycle_policy"></a> [efs\_lifecycle\_policy](#input\_efs\_lifecycle\_policy) | Lifecycle Policy for the EFS Filesystem | <pre>list(object({<br/>    transition_to_ia                    = string<br/>    transition_to_primary_storage_class = string<br/>  }))</pre> | `[]` | no |
@@ -174,7 +175,7 @@ module "eks" {
 | <a name="output_aws_iam_instance_profile_node"></a> [aws\_iam\_instance\_profile\_node](#output\_aws\_iam\_instance\_profile\_node) | The instance profile associated with the EKS worker nodes |
 | <a name="output_aws_iam_role_node"></a> [aws\_iam\_role\_node](#output\_aws\_iam\_role\_node) | The IAM role assigned to the EKS worker nodes for managing permissions |
 | <a name="output_aws_security_group_cluster"></a> [aws\_security\_group\_cluster](#output\_aws\_security\_group\_cluster) | The security group applied to the EKS cluster for network control |
-| <a name="output_datadog_agent_cluster_role_name"></a> [datadog\_agent\_cluster\_role\_name](#output\_datadog\_agent\_cluster\_role\_name) | The ClusterRole created in order to configure Datadog Agent |
+| <a name="output_datadog_agent_cluster_role_name"></a> [datadog\_agent\_cluster\_role\_name](#output\_datadog\_agent\_cluster\_role\_name) | Name of the ClusterRole to create in order to configure Datadog Agents |
 | <a name="output_efs"></a> [efs](#output\_efs) | The Amazon EFS (Elastic File System) configuration for the cluster, if available |
 | <a name="output_eks_default_auth_role_arn"></a> [eks\_default\_auth\_role\_arn](#output\_eks\_default\_auth\_role\_arn) | The ARN of the IAM role used for default EKS authentication |
 | <a name="output_fargate_profile"></a> [fargate\_profile](#output\_fargate\_profile) | Details of the Fargate profile configured for the EKS cluster |

--- a/aws/eks-cluster/README.md
+++ b/aws/eks-cluster/README.md
@@ -1,14 +1,19 @@
 # AWS EKS Terraform module
+
 Terraform module which creates Amazon EKS (Kubernetes) resources
 
 This module will create the components below
-- Default system applications like: coredns, metrics-server, aws-load-balancer-controller, nginx-ingress-controller
+
+- Default system applications like: coredns, metrics-server,
+  aws-load-balancer-controller, nginx-ingress-controller
 - Associated IAM components for running the cluster
 - Default nodes and Fargate profile for running pods
 - EFS system for mounting volumes
 
 ## Usage
+
 ### Create EKS cluster
+
 ```hcl
 module "eks" {
   source  = "github.com/spartan-stratos/terraform-modules//aws/eks-cluster?ref=v0.1.0"
@@ -56,26 +61,27 @@ module "eks" {
 ```
 
 ## Examples
+
 - [Example Fargate](./examples/fargate/)
 - [Example Managed nodes](./examples/managed-nodes/)
 
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
-| Name | Version    |
-|------|------------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9.8   |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | \>= 5.75   |
-| <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | \>= 2.33.0 |
-| <a name="requirement_tls"></a> [tls](#requirement\_tls) | \>= 4.0    |
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9.8 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.75 |
+| <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 2.33.0 |
+| <a name="requirement_tls"></a> [tls](#requirement\_tls) | >= 4.0 |
 
 ## Providers
 
-| Name | Version    |
-|------|------------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | \>= 5.75   |
-| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | \>= 2.33.0 |
-| <a name="provider_tls"></a> [tls](#provider\_tls) | \>= 4.0    |
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.75 |
+| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | >= 2.33.0 |
+| <a name="provider_tls"></a> [tls](#provider\_tls) | >= 4.0 |
 
 ## Modules
 
@@ -168,6 +174,7 @@ module "eks" {
 | <a name="output_aws_iam_instance_profile_node"></a> [aws\_iam\_instance\_profile\_node](#output\_aws\_iam\_instance\_profile\_node) | The instance profile associated with the EKS worker nodes |
 | <a name="output_aws_iam_role_node"></a> [aws\_iam\_role\_node](#output\_aws\_iam\_role\_node) | The IAM role assigned to the EKS worker nodes for managing permissions |
 | <a name="output_aws_security_group_cluster"></a> [aws\_security\_group\_cluster](#output\_aws\_security\_group\_cluster) | The security group applied to the EKS cluster for network control |
+| <a name="output_datadog_agent_cluster_role_name"></a> [datadog\_agent\_cluster\_role\_name](#output\_datadog\_agent\_cluster\_role\_name) | The ClusterRole created in order to configure Datadog Agent |
 | <a name="output_efs"></a> [efs](#output\_efs) | The Amazon EFS (Elastic File System) configuration for the cluster, if available |
 | <a name="output_eks_default_auth_role_arn"></a> [eks\_default\_auth\_role\_arn](#output\_eks\_default\_auth\_role\_arn) | The ARN of the IAM role used for default EKS authentication |
 | <a name="output_fargate_profile"></a> [fargate\_profile](#output\_fargate\_profile) | Details of the Fargate profile configured for the EKS cluster |

--- a/aws/eks-cluster/datadog-rbac.tf
+++ b/aws/eks-cluster/datadog-rbac.tf
@@ -1,7 +1,8 @@
 module "datadog_rbac" {
-  count                   = var.create_fargate_profile == true && var.enabled_datadog_agent == true ? 1 : 0
-  source                  = "./modules/datadog-rbac"
-  fargate_profiles        = var.fargate_profiles
-  default_service_account = var.default_service_account
-  custom_namespaces       = var.custom_namespaces
+  count                           = var.create_fargate_profile == true && var.enabled_datadog_agent == true ? 1 : 0
+  source                          = "./modules/datadog-rbac"
+  fargate_profiles                = var.fargate_profiles
+  default_service_account         = var.default_service_account
+  custom_namespaces               = var.custom_namespaces
+  datadog_agent_cluster_role_name = local.datadog_agent_cluster_role_name
 }

--- a/aws/eks-cluster/datadog-rbac.tf
+++ b/aws/eks-cluster/datadog-rbac.tf
@@ -4,5 +4,5 @@ module "datadog_rbac" {
   fargate_profiles                = var.fargate_profiles
   default_service_account         = var.default_service_account
   custom_namespaces               = var.custom_namespaces
-  datadog_agent_cluster_role_name = local.datadog_agent_cluster_role_name
+  datadog_agent_cluster_role_name = var.datadog_agent_cluster_role_name
 }

--- a/aws/eks-cluster/iam.tf
+++ b/aws/eks-cluster/iam.tf
@@ -177,7 +177,7 @@ data "aws_iam_policy_document" "node_assume_role_policy" {
 
     principals {
       type        = "Service"
-      identifiers = ["eks.amazonaws.com"]
+      identifiers = ["ec2.amazonaws.com"]
     }
   }
 }

--- a/aws/eks-cluster/locals.tf
+++ b/aws/eks-cluster/locals.tf
@@ -3,4 +3,6 @@ locals {
 
   cluster_name = "${var.name}-eks-${var.environment}"
   namespaces   = { for namespace in var.custom_namespaces : namespace => namespace }
+
+  datadog_agent_cluster_role_name = "datadog-agent"
 }

--- a/aws/eks-cluster/locals.tf
+++ b/aws/eks-cluster/locals.tf
@@ -3,6 +3,4 @@ locals {
 
   cluster_name = "${var.name}-eks-${var.environment}"
   namespaces   = { for namespace in var.custom_namespaces : namespace => namespace }
-
-  datadog_agent_cluster_role_name = "datadog-agent"
 }

--- a/aws/eks-cluster/modules/datadog-rbac/README.md
+++ b/aws/eks-cluster/modules/datadog-rbac/README.md
@@ -18,16 +18,16 @@ module "datadog_rbac" {
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
-| Name | Version    |
-|------|------------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9.8   |
-| <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | \>= 2.33.0 |
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9.8 |
+| <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 2.33.0 |
 
 ## Providers
 
-| Name | Version    |
-|------|------------|
-| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | \>= 2.33.0 |
+| Name | Version |
+|------|---------|
+| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | >= 2.33.0 |
 
 ## Modules
 
@@ -45,7 +45,7 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_custom_namespaces"></a> [custom\_namespaces](#input\_custom\_namespaces) | Custom namespaces to be created during initialization | `list(string)` | `[]` | no |
-| <a name="input_datadog_agent_cluster_role_name"></a> [datadog\_agent\_cluster\_role\_name](#input\_datadog\_agent\_cluster\_role\_name) | n/a | `string` | `"datadog-agent"` | no |
+| <a name="input_datadog_agent_cluster_role_name"></a> [datadog\_agent\_cluster\_role\_name](#input\_datadog\_agent\_cluster\_role\_name) | Name of the ClusterRole to create in order to configure Datadog Agents | `string` | n/a | yes |
 | <a name="input_default_service_account"></a> [default\_service\_account](#input\_default\_service\_account) | Default service account name for binding with Datadog | `string` | `"default"` | no |
 | <a name="input_fargate_profiles"></a> [fargate\_profiles](#input\_fargate\_profiles) | Configuration block(s) for selecting Kubernetes Pods to execute with this Fargate Profile | `any` | `{}` | no |
 

--- a/aws/eks-cluster/modules/datadog-rbac/variables.tf
+++ b/aws/eks-cluster/modules/datadog-rbac/variables.tf
@@ -1,6 +1,5 @@
 variable "datadog_agent_cluster_role_name" {
   type    = string
-  default = "datadog-agent"
 }
 
 variable "fargate_profiles" {

--- a/aws/eks-cluster/modules/datadog-rbac/variables.tf
+++ b/aws/eks-cluster/modules/datadog-rbac/variables.tf
@@ -1,5 +1,6 @@
 variable "datadog_agent_cluster_role_name" {
-  type    = string
+  type        = string
+  description = "Name of the ClusterRole to create in order to configure Datadog Agents"
 }
 
 variable "fargate_profiles" {

--- a/aws/eks-cluster/outputs.tf
+++ b/aws/eks-cluster/outputs.tf
@@ -45,6 +45,7 @@ output "aws_eks_cluster_auth_data" {
 }
 
 output "datadog_agent_cluster_role_name" {
-  value       = local.datadog_agent_cluster_role_name
-  description = "The ClusterRole created in order to configure Datadog Agent"
+  # we need to output a var because it has a default value
+  value       = var.datadog_agent_cluster_role_name
+  description = "Name of the ClusterRole to create in order to configure Datadog Agents"
 }

--- a/aws/eks-cluster/outputs.tf
+++ b/aws/eks-cluster/outputs.tf
@@ -43,3 +43,8 @@ output "aws_eks_cluster_auth_data" {
   value       = local.aws_auth_configmap_data
   description = "The ConfigMap data for managing EKS cluster authentication"
 }
+
+output "datadog_agent_cluster_role_name" {
+  value       = local.datadog_agent_cluster_role_name
+  description = "The ClusterRole created in order to configure Datadog Agent"
+}

--- a/aws/eks-cluster/variables.tf
+++ b/aws/eks-cluster/variables.tf
@@ -152,6 +152,12 @@ variable "enabled_datadog_agent" {
   default     = false
 }
 
+variable "datadog_agent_cluster_role_name" {
+  type        = string
+  description = "Name of the ClusterRole to create in order to configure Datadog Agents"
+  default     = "datadog-agent"
+}
+
 variable "enabled_cluster_log_types" {
   type        = list(string)
   default     = ["api", "audit", "authenticator", "controllerManager", "scheduler"]


### PR DESCRIPTION
## Summary
- Add output datadog_agent_cluster_role_name to root module and remove default value of datadog_agent_cluster_role_name in submodule
- Change the assume policy of eks-node-cluster from eks.amazonaws.com to ec2.amazonaws.com

### Why
- Add output: necessary for bridgehealth adaption, since other resources relied on this output.
- Change assume policy: to match with bridgehealth-ai eks cluster, and document https://docs.aws.amazon.com/eks/latest/userguide/create-node-role.html. I don't understand why the original assume policy was  `eks.amazonaws.com` for the node role though.
### What

### Solution

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply --->
- [x] ❌ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 🕷 Bug fix (non-breaking change which fixes an issue)
- [ ] 👏 Performance optimization (non-breaking change which addresses a performance issue)
- [x] 🛠 Refactor (non-breaking change which does not change existing behavior or add new functionality)
- [ ] 📗 Library update (non-breaking change that will update one or more libraries to newer versions)
- [ ] 📝 Documentation (non-breaking change that doesn't change code behavior, can skip testing)
- [ ] ✅ Test (non-breaking change related to testing)
- [ ] 🔒 Security awareness (changes that effect permission scope, security scenarios)

## Test Plan
<!--- Please input steps on how to test this PR, including evidence in the form of captured images or videos. If this is not necessary, provide the reason why. --->

## Related Issues
<!--- Add a reference section for management tickets, and relevant conversations. --->
