### PR TITLE
fix: correct AWS RDS condition error

### DIFF
--- a/aws/postgres/CHANGELOG.md
+++ b/aws/postgres/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.22]() (2024-12-25)
+### Features
+* Correct conditions to create security group `aws_security_group.this` when variable `vpc_security_group_ids` is null.
+
 ## [0.1.15]() (2024-12-19)
 ### Features
 * Add `var.custom_parameter_group_name` and `var.vpc_security_group_ids` to overwrite parameter group name and use exising security group ids.

--- a/aws/postgres/main.tf
+++ b/aws/postgres/main.tf
@@ -14,7 +14,7 @@ resource "aws_db_subnet_group" "this" {
 }
 
 resource "aws_security_group" "this" {
-  count = var.vpc_security_group_ids == null ? 0 : 1
+  count = var.vpc_security_group_ids == null ? 1 : 0
 
   name        = "Allow ${local.identifier} RDS"
   description = "Allow RDS inbound traffic and outbound traffic inside the VPC"
@@ -22,7 +22,7 @@ resource "aws_security_group" "this" {
 }
 
 resource "aws_vpc_security_group_ingress_rule" "this" {
-  count = var.vpc_security_group_ids == null ? 0 : 1
+  count = var.vpc_security_group_ids == null ? 1 : 0
 
   security_group_id = aws_security_group.this[0].id
   cidr_ipv4         = data.aws_vpc.this.cidr_block
@@ -32,7 +32,7 @@ resource "aws_vpc_security_group_ingress_rule" "this" {
 }
 
 resource "aws_vpc_security_group_egress_rule" "this" {
-  count = var.vpc_security_group_ids == null ? 0 : 1
+  count = var.vpc_security_group_ids == null ? 1 : 0
 
   security_group_id = aws_security_group.this[0].id
   cidr_ipv4         = "0.0.0.0/0"


### PR DESCRIPTION
## Summary
<!--- Add some bells and whistles for PR template. --->
fix: correct AWS RDS condition error
* Correct conditions to create security group `aws_security_group.this` when variable `vpc_security_group_ids` is null.

### Why
<!--- Clearly define the issue or problem that your changes address. 
Describe what is currently not working as expected or what feature is missing. --->

### What
<!--- Provide a high-level overview of what has been modified, added, or removed in the codebase. 
This could include new features, bug fixes, refactoring efforts, or performance optimizations. --->

### Solution
<!--- Describe the architectural or design decisions you made while implementing the changes.
Explain the thought process behind your approach and how it aligns with best practices or existing patterns in the codebase. --->

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply --->
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 🕷 Bug fix (non-breaking change which fixes an issue)
- [ ] 👏 Performance optimization (non-breaking change which addresses a performance issue)
- [x] 🛠 Refactor (non-breaking change which does not change existing behavior or add new functionality)
- [ ] 📗 Library update (non-breaking change that will update one or more libraries to newer versions)
- [ ] 📝 Documentation (non-breaking change that doesn't change code behavior, can skip testing)
- [ ] ✅ Test (non-breaking change related to testing)
- [ ] 🔒 Security awareness (changes that effect permission scope, security scenarios)

## Test Plan
<!--- Please input steps on how to test this PR, including evidence in the form of captured images or videos. If this is not necessary, provide the reason why. --->

Luckily, the usage of `var.vpc_security_group_ids` is working as expected so only redundant resources created, does not affect directly to the RDS's security group.

## Related Issues
<!--- Add a reference section for management tickets, and relevant conversations. --->
https://www.notion.so/c0x12c/Infra-Rollout-new-Terraform-to-Daxe-15701fb05bf180f9a19ddfc2e19d2f00?pvs=4