### PR TITLE
Add support for EC2 InstanceId in CloudWatch alarm variables

### DIFF
--- a/aws/cloudwatch/alarm/CHANGELOG.md
+++ b/aws/cloudwatch/alarm/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [0.1.33]() (2025-01-02)
+### Fix
+* Ensure InstanceId is included when the namespace is "AWS/EC2".
+
 ## [0.1.11]() (2024-16-09)
 ### Features
 * Initialized module for CloudWatch Alarm

--- a/aws/cloudwatch/alarm/README.md
+++ b/aws/cloudwatch/alarm/README.md
@@ -1,34 +1,4 @@
 <!-- BEGIN_TF_DOCS -->
-
-# Amazon CloudWatch Alarm Terraform module
-Terraform module which creates Amazon CloudWatch Alarm resources.
-
-## Usage
-```hcl
-module "cloudwatch-alarm" {
-  source  = "github.com/spartan-stratos/terraform-modules//aws/cloudwatch/alarm?ref=v0.1.11"
-
-  email = "example-email"
-  environment = "dev"
-  alarms = {
-    CPUUtilization = {
-      name                = "example-alarm"
-      description         = "example"
-      comparison_operator = "example-comparison"
-      evaluation_periods  = "1"
-      metric_name         = "exammple-metric"
-      namespace           = "example-namespace"
-      period              = "example-period"
-      statistic           = "Average"
-      threshold           = "20"
-    }
-  }
-}
-```
-
-## Examples
-- [Example complete](./examples/complete/)
-
 ## Requirements
 
 | Name | Version |
@@ -58,7 +28,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_alarms"></a> [alarms](#input\_alarms) | A map of alarms to create | <pre>map(object({<br/>    name                = string<br/>    description         = string<br/>    comparison_operator = string<br/>    evaluation_periods  = string<br/>    metric_name         = string<br/>    namespace           = string<br/>    period              = string<br/>    statistic           = string<br/>    threshold           = number<br/>    queue_name          = optional(string)<br/>  }))</pre> | n/a | yes |
+| <a name="input_alarms"></a> [alarms](#input\_alarms) | A map of alarms to create | <pre>map(object({<br/>    name                = string<br/>    description         = string<br/>    comparison_operator = string<br/>    evaluation_periods  = string<br/>    metric_name         = string<br/>    namespace           = string<br/>    period              = string<br/>    statistic           = string<br/>    threshold           = number<br/>    queue_name          = optional(string)<br/>    alb_name            = optional(string)<br/>    target_group_name   = optional(string)<br/>    instance_id         = optional(string)<br/>  }))</pre> | n/a | yes |
 | <a name="input_create_sns_topic"></a> [create\_sns\_topic](#input\_create\_sns\_topic) | Creates a SNS Topic if `true`. | `bool` | `true` | no |
 | <a name="input_datapoints_to_alarm"></a> [datapoints\_to\_alarm](#input\_datapoints\_to\_alarm) | The number of datapoints that must be breaching to trigger the alarm. | `number` | `null` | no |
 | <a name="input_email"></a> [email](#input\_email) | n/a | `string` | n/a | yes |

--- a/aws/cloudwatch/alarm/README.md
+++ b/aws/cloudwatch/alarm/README.md
@@ -1,3 +1,31 @@
+# Amazon CloudWatch Alarm Terraform module
+Terraform module which creates Amazon CloudWatch Alarm resources.
+
+## Usage
+```hcl
+module "cloudwatch-alarm" {
+  source  = "github.com/spartan-stratos/terraform-modules//aws/cloudwatch/alarm?ref=v0.1.33"
+  email = "example-email"
+  environment = "dev"
+  alarms = {
+    CPUUtilization = {
+      name                = "example-alarm"
+      description         = "example"
+      comparison_operator = "example-comparison"
+      evaluation_periods  = "1"
+      metric_name         = "exammple-metric"
+      namespace           = "example-namespace"
+      period              = "example-period"
+      statistic           = "Average"
+      threshold           = "20"
+    }
+  }
+}
+```
+
+## Examples
+- [Example complete](./examples/complete/)
+
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 

--- a/aws/cloudwatch/alarm/main.tf
+++ b/aws/cloudwatch/alarm/main.tf
@@ -24,7 +24,8 @@ resource "aws_cloudwatch_metric_alarm" "this" {
       { LoadBalancer = each.value.alb_name },
       each.value.target_group_name != null ? { TargetGroup = each.value.target_group_name } : {}
     )
-    : {}
+    : {},
+    each.value.namespace == "AWS/EC2" ? { InstanceId = each.value.instance_id } : {}
   )
 }
 

--- a/aws/cloudwatch/alarm/variables.tf
+++ b/aws/cloudwatch/alarm/variables.tf
@@ -45,6 +45,7 @@ variable "alarms" {
     queue_name          = optional(string)
     alb_name            = optional(string)
     target_group_name   = optional(string)
+    instance_id         = optional(string)
   }))
 }
 

--- a/aws/openvpn/CHANGELOG.md
+++ b/aws/openvpn/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [0.1.33]() (2025-01-02)
+### Fix
+* Add outputs for EC2 instance.
+
 ## [0.1.31]() (2024-12-30)
 ### Fix
 * Fix missing a new line in the init script cause server not configure properly.

--- a/aws/openvpn/README.md
+++ b/aws/openvpn/README.md
@@ -40,9 +40,9 @@ module "openvpn" {
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.82.2 |
-| <a name="provider_random"></a> [random](#provider\_random) | 3.6.3 |
-| <a name="provider_tls"></a> [tls](#provider\_tls) | 4.0.6 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.75 |
+| <a name="provider_random"></a> [random](#provider\_random) | >= 3.6.3 |
+| <a name="provider_tls"></a> [tls](#provider\_tls) | >= 4.0.6 |
 
 ## Modules
 
@@ -107,6 +107,8 @@ No modules.
 | Name | Description |
 |------|-------------|
 | <a name="output_ca_cert"></a> [ca\_cert](#output\_ca\_cert) | The OpenVPN CA certificate. |
+| <a name="output_instance_id"></a> [instance\_id](#output\_instance\_id) | The ID of the AWS instance. |
+| <a name="output_instant_arn"></a> [instant\_arn](#output\_instant\_arn) | The ARN of the AWS instance. |
 | <a name="output_ovpn_file"></a> [ovpn\_file](#output\_ovpn\_file) | n/a |
 | <a name="output_public_ip"></a> [public\_ip](#output\_public\_ip) | The public IP address of the OpenVPN instance. |
 | <a name="output_ssh_private_key"></a> [ssh\_private\_key](#output\_ssh\_private\_key) | The private key for the management SSH key pair. |

--- a/aws/openvpn/README.md
+++ b/aws/openvpn/README.md
@@ -8,7 +8,7 @@ Terraform module which creates OpenVPN to access internal VPC network.
 
 ```hcl
 module "openvpn" {
-  source = "github.com/spartan-stratos/terraform-modules//aws/openvpn?ref=v0.1.13"
+  source = "github.com/spartan-stratos/terraform-modules//aws/openvpn?ref=v0.1.33"
 
   vpn_name    = "openvpn"
   domain_name = "example.com"

--- a/aws/openvpn/outputs.tf
+++ b/aws/openvpn/outputs.tf
@@ -45,3 +45,13 @@ output "ca_cert" {
   value       = tls_self_signed_cert.ca.cert_pem
   description = "The OpenVPN CA certificate."
 }
+
+output "instance_id" {
+  value       = try(aws_instance.this[0].id, "")
+  description = "The ID of the AWS instance."
+}
+
+output "instant_arn" {
+  value       = try(aws_instance.this[0].arn, "")
+  description = "The ARN of the AWS instance."
+}

--- a/datadog/aws-monitor/examples/main.tf
+++ b/datadog/aws-monitor/examples/main.tf
@@ -1,8 +1,8 @@
 module "aws_monitor" {
   source = "../"
 
-  environment                       = "prod"
-  tag_slack_channel                 = true
+  environment       = "prod"
+  tag_slack_channel = true
 
   aws_account_id                    = "123456789012"
   notification_slack_channel_prefix = "prj-service-x-"


### PR DESCRIPTION
## Summary
<!--- Add some bells and whistles for PR template. --->

- This update introduces the `instance_id` variable for EC2 alarms and ensures `InstanceId` is included when the namespace is "AWS/EC2". 
- Minor formatting adjustments were made in the example configuration for consistency.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply --->
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 🕷 Bug fix (non-breaking change which fixes an issue)
- [ ] 👏 Performance optimization (non-breaking change which addresses a performance issue)
- [ ] 🛠 Refactor (non-breaking change which does not change existing behavior or add new functionality)
- [ ] 📗 Library update (non-breaking change that will update one or more libraries to newer versions)
- [ ] 📝 Documentation (non-breaking change that doesn't change code behavior, can skip testing)
- [ ] ✅ Test (non-breaking change related to testing)
- [ ] 🔒 Security awareness (changes that effect permission scope, security scenarios)

## Test Plan
Terraform plan

## Related Issues
N/A
