### PR TITLE
Add metadata options configuration for EC2 instances

### DIFF
--- a/aws/openvpn/CHANGELOG.md
+++ b/aws/openvpn/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 ## [0.1.33]() (2025-01-02)
 ### Fix
 * Add outputs for EC2 instance.
+* Introduced `http_tokens` and `http_endpoint` variables to control instance metadata service settings.
 
 ## [0.1.31]() (2024-12-30)
 ### Fix

--- a/aws/openvpn/README.md
+++ b/aws/openvpn/README.md
@@ -82,6 +82,8 @@ No modules.
 | <a name="input_disk_boot_size"></a> [disk\_boot\_size](#input\_disk\_boot\_size) | The size of the boot disk in GB. | `number` | `"10"` | no |
 | <a name="input_domain_name"></a> [domain\_name](#input\_domain\_name) | The domain name. | `string` | n/a | yes |
 | <a name="input_extra_sg_ids"></a> [extra\_sg\_ids](#input\_extra\_sg\_ids) | A list of additional security group IDs. | `list(string)` | `[]` | no |
+| <a name="input_http_endpoint"></a> [http\_endpoint](#input\_http\_endpoint) | The configuration for enabling or disabling the instance metadata service endpoint. | `string` | `"enabled"` | no |
+| <a name="input_http_tokens"></a> [http\_tokens](#input\_http\_tokens) | The configuration for the instance metadata service tokens. | `string` | `"optional"` | no |
 | <a name="input_image_distro"></a> [image\_distro](#input\_image\_distro) | The distribution of the image. | `string` | `"debian-12-amd64"` | no |
 | <a name="input_image_version"></a> [image\_version](#input\_image\_version) | The version of the image. | `string` | `"20240717-1811"` | no |
 | <a name="input_init_script_callback_comment"></a> [init\_script\_callback\_comment](#input\_init\_script\_callback\_comment) | The callback name for the OpenVPN server | `string` | `"Google Oauth 2.0 callback"` | no |

--- a/aws/openvpn/instance.tf
+++ b/aws/openvpn/instance.tf
@@ -41,6 +41,11 @@ resource "aws_instance" "this" {
     encrypted = true
   }
 
+  metadata_options {
+    http_tokens   = var.http_tokens
+    http_endpoint = var.http_endpoint
+  }
+
   user_data_replace_on_change = true
   user_data                   = templatefile("${path.module}/scripts/install_openvpn.sh", local.openvpn_config)
 
@@ -71,6 +76,11 @@ resource "aws_instance" "replacable" {
 
   root_block_device {
     encrypted = true
+  }
+
+  metadata_options {
+    http_tokens   = var.http_tokens
+    http_endpoint = var.http_endpoint
   }
 
   user_data_replace_on_change = true

--- a/aws/openvpn/variables.tf
+++ b/aws/openvpn/variables.tf
@@ -144,3 +144,15 @@ variable "init_script_callback_comment" {
   type        = string
   default     = "Google Oauth 2.0 callback"
 }
+
+variable "http_tokens" {
+  type        = string
+  description = "The configuration for the instance metadata service tokens."
+  default     = "optional"
+}
+
+variable "http_endpoint" {
+  type        = string
+  description = "The configuration for enabling or disabling the instance metadata service endpoint."
+  default     = "enabled"
+}


### PR DESCRIPTION
## Summary
<!--- Add some bells and whistles for PR template. --->

- Introduced `http_tokens` and `http_endpoint` variables to control instance metadata service settings. 
([http_tokens](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/instance#http_tokens-1) - (Optional) Whether or not the metadata service requires session tokens, also referred to as Instance Metadata Service Version 2 (IMDSv2). Valid values include optional or required.)
- Updated instance configurations to include these metadata options, enhancing control over metadata access and security.

- Default: 
![image](https://github.com/user-attachments/assets/b1d0aaea-ed44-489d-b3f3-fd44bcfe49e6)

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply --->
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 🕷 Bug fix (non-breaking change which fixes an issue)
- [ ] 👏 Performance optimization (non-breaking change which addresses a performance issue)
- [x] 🛠 Refactor (non-breaking change which does not change existing behavior or add new functionality)
- [ ] 📗 Library update (non-breaking change that will update one or more libraries to newer versions)
- [ ] 📝 Documentation (non-breaking change that doesn't change code behavior, can skip testing)
- [ ] ✅ Test (non-breaking change related to testing)
- [ ] 🔒 Security awareness (changes that effect permission scope, security scenarios)

## Test Plan
Terraform plan

## Related Issues
N/A
