### PR TITLE
Handle "-1" IP protocol in from/to port values 

### DIFF
--- a/aws/security-group/CHANGELOG.md
+++ b/aws/security-group/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [0.1.33]() (2025-01-02)
+### Features
+* Updated the logic to set from_port and to_port to -1 when the IP protocol is "-1", ensuring compatibility for security group rules with all protocols.
+
 ## [0.1.30]() (2024-12-30)
 ### Features
 * Update Security Group Resources to Support Dynamic Ingress and Egress Rule Management

--- a/aws/security-group/README.md
+++ b/aws/security-group/README.md
@@ -9,34 +9,35 @@ This module will create the following components:
 ### Create Custom Security Groups
 ```hcl
 module "security_groups" {
-  source = "github.com/spartan-stratos/terraform-modules//aws/security-group?ref=v0.1.30"
+  source = "github.com/spartan-stratos/terraform-modules//aws/security-group?ref=v0.1.33"
   
   create_default_security_group = false
   security_groups = {
     "example-sg" = {
       name        = "example-sg"
-      description              = "Example Security Group"
-      vpc_id                   = "vpc-12345678"
+      description = "Example Security Group"
+      vpc_id      = "vpc-12345678"
       ingress_rules = {
         "rule1" = {
-          from_port        = 0
-          to_port          = 0
-          protocol         = "-1"
-          cidr_ipv4        = "0.0.0.0/0"
-          cidr_ipv6        = "::/0"
-          self             = true
-          description      = "Example Rule 1"
+          protocol    = "-1"
+          cidr_ipv4   = "0.0.0.0/0"
+          cidr_ipv6   = "::/0"
+          description = "Example Rule 1"
+        }
+        "rule2" = {
+          from_port   = 0
+          to_port     = 0
+          protocol    = "-1"
+          self        = true
+          description = "Allow unrestricted traffic within this security group"
         }
       }
       egress_rules = {
         "rule1" = {
-          from_port   = 0
-          to_port     = 0
           protocol    = "-1"
-          cidr_ipv4 = "0.0.0.0/0"
-          cidr_ipv6        = "::/0"
-          self             = true
-          description = "Example Rule 2"
+          cidr_ipv4   = "0.0.0.0/0"
+          cidr_ipv6   = "::/0"
+          description = "Example Rule 1"
         }
       }
     }
@@ -99,9 +100,7 @@ No modules.
 | <a name="input_custom_sg_allow_all_description"></a> [custom\_sg\_allow\_all\_description](#input\_custom\_sg\_allow\_all\_description) | Custom description for security group allow all `aws_security_group.allow_all`. | `string` | `null` | no |
 | <a name="input_custom_sg_allow_all_within_vpc_description"></a> [custom\_sg\_allow\_all\_within\_vpc\_description](#input\_custom\_sg\_allow\_all\_within\_vpc\_description) | Custom description for security group allow all within vpc `aws_security_group.allow_all_within_vpc`. | `string` | `null` | no |
 | <a name="input_custom_sg_allow_all_within_vpc_egress_ipv6_cidr_blocks"></a> [custom\_sg\_allow\_all\_within\_vpc\_egress\_ipv6\_cidr\_blocks](#input\_custom\_sg\_allow\_all\_within\_vpc\_egress\_ipv6\_cidr\_blocks) | Custom IPv6 CIDR blocks to allow in the egress rules for the security group allow\_all\_within\_vpc | `list(string)` | <pre>[<br/>  "::/0"<br/>]</pre> | no |
-| <a name="input_security_groups"></a> [security\_groups](#input\_security\_groups) | A map of security groups with their associated ingress and egress rules, to be applied to a VPC. | <pre>map(object({<br/>    name        = string<br/>    description = string<br/>    vpc_id      = string<br/>    ingress_rules = optional(map(object({<br/>      from_port   = optional(number, null)  # Port range start for ingress traffic, null means not specified<br/>      to_port     = optional(number, null)  # Port range end for ingress traffic, null means not specified<br/>      protocol    = optional(string, null)  # Protocol for ingress traffic (e.g., 'tcp', 'udp', etc.), null means not specified<br/>      cidr_ipv4   = optional(string, null)  # IPv4 CIDR block for ingress traffic, null means not specified<br/>      cidr_ipv6   = optional(string, null)  # IPv6 CIDR block for ingress traffic, null means not specified<br/>      description = optional(string, null)  # Description of the ingress rule, null means not specified<br/>      self        = optional(bool, false)   # Whether to allow traffic from the security group itself, defaults to false<br/>    })), null)  # A map of ingress rules for the security group, can be null if no ingress rules are specified<br/><br/>    egress_rules = optional(map(object({<br/>      from_port   = optional(number, null)  # Port range start for egress traffic, null means not specified<br/>      to_port     = optional(number, null)  # Port range end for egress traffic, null means not specified<br/>      protocol    = optional(string, null)  # Protocol for egress traffic (e.g., 'tcp', 'udp', etc.), null means not specified<br/>      cidr_ipv4   = optional(string, null)  # IPv4 CIDR block for egress traffic, null means not specified<br/>      cidr_ipv6   = optional(string, null)  # IPv6 CIDR block for egress traffic, null means not specified<br/>      description = optional(string, null)  # Description of the egress rule, null means not specified<br/>      self        = optional(bool, false)   # Whether to allow traffic to the security group itself, defaults to false<br/>    })), null)  # A map of egress rules for the security group, can be null if no egress rules are specified<br/>  }))</pre> | `null` | no |
-| <a name="input_rules"></a> [rules](#input\_rules) | Map of known security group rules (define as 'name' = ['from port', 'to port', 'protocol', 'description']) | `map(list(any))` | `null` | no |
-| <a name="input_security_groups"></a> [security\_groups](#input\_security\_groups) | A list of objects defining custom security groups. Each security group object should include the following properties:<br/>- `name` (string): The name of the security group.<br/>- `description` (string): A description of the security group's purpose.<br/>- `vpc_id` (string): The VPC ID where the security group will be created.<br/>- `ingress_rules` (list(string)): A list of ingress rule names defined in the `rules` variable.<br/>- `ingress_cidr_blocks` (optional, list(string)): CIDR blocks to allow in the ingress rules. Default is an empty list.<br/>- `ingress_ipv6_cidr_blocks` (optional, list(string)): IPv6 CIDR blocks to allow in the ingress rules. Default is an empty list.<br/>- `ingress_self` (optional, list(bool)): Whether to allow self-referencing ingress rules. Default is an empty list.<br/>- `egress_rules` (list(string)): A list of egress rule names defined in the `rules` variable.<br/>- `egress_cidr_blocks` (optional, list(string)): CIDR blocks to allow in the egress rules. Default is an empty list.<br/>- `egress_ipv6_cidr_blocks` (optional, list(string)): IPv6 CIDR blocks to allow in the egress rules. Default is an empty list.<br/>- `egress_self` (optional, list(bool)): Whether to allow selsf-referencing egress rules. Default is an empty list.<br/>- `tags` (optional, map(string))): A map of tags to | <pre>list(object({<br/>    name                     = string<br/>    description              = string<br/>    vpc_id                   = string<br/>    ingress_rules            = list(string)<br/>    ingress_cidr_blocks      = optional(list(string))<br/>    ingress_ipv6_cidr_blocks = optional(list(string), [])<br/>    ingress_self             = optional(list(bool), [false])<br/>    egress_rules             = list(string)<br/>    egress_cidr_blocks       = optional(list(string))<br/>    egress_ipv6_cidr_blocks  = optional(list(string), [])<br/>    egress_self              = optional(list(bool), [false])<br/>    tags                     = optional(map(string), {})<br/>  }))</pre> | `null` | no |
+| <a name="input_security_groups"></a> [security\_groups](#input\_security\_groups) | A map of security groups with their associated ingress and egress rules, to be applied to a VPC. | <pre>map(object({<br/>    name        = string<br/>    description = string<br/>    vpc_id      = string<br/>    ingress_rules = optional(map(object({<br/>      from_port   = optional(number, null) # Port range start for ingress traffic, null means not specified<br/>      to_port     = optional(number, null) # Port range end for ingress traffic, null means not specified<br/>      protocol    = optional(string, null) # Protocol for ingress traffic (e.g., 'tcp', 'udp', etc.), null means not specified<br/>      cidr_ipv4   = optional(string, null) # IPv4 CIDR block for ingress traffic, null means not specified<br/>      cidr_ipv6   = optional(string, null) # IPv6 CIDR block for ingress traffic, null means not specified<br/>      description = optional(string, null) # Description of the ingress rule, null means not specified<br/>      self        = optional(bool, false)  # Whether to allow traffic from the security group itself, defaults to false<br/>    })), null)                             # A map of ingress rules for the security group, can be null if no ingress rules are specified<br/>    egress_rules = optional(map(object({<br/>      from_port   = optional(number, null) # Port range start for egress traffic, null means not specified<br/>      to_port     = optional(number, null) # Port range end for egress traffic, null means not specified<br/>      protocol    = optional(string, null) # Protocol for egress traffic (e.g., 'tcp', 'udp', etc.), null means not specified<br/>      cidr_ipv4   = optional(string, null) # IPv4 CIDR block for egress traffic, null means not specified<br/>      cidr_ipv6   = optional(string, null) # IPv6 CIDR block for egress traffic, null means not specified<br/>      description = optional(string, null) # Description of the egress rule, null means not specified<br/>      self        = optional(bool, false)  # Whether to allow traffic to the security group itself, defaults to false<br/>    })), null)<br/>    tags = optional(map(string), {}) # A map of egress rules for the security group, can be null if no egress rules are specified<br/>  }))</pre> | `null` | no |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | ID of the main VPC associated with the security groups. Can be null if not provided. | `string` | `null` | no |
 
 ## Outputs

--- a/aws/security-group/examples/complete/main.tf
+++ b/aws/security-group/examples/complete/main.tf
@@ -9,24 +9,25 @@ module "aws_custom_security_groups" {
       vpc_id      = "vpc-12345678"
       ingress_rules = {
         "rule1" = {
-          from_port   = 0
-          to_port     = 0
           protocol    = "-1"
           cidr_ipv4   = "0.0.0.0/0"
           cidr_ipv6   = "::/0"
-          self        = true
           description = "Example Rule 1"
+        }
+        "rule2" = {
+          from_port   = 0
+          to_port     = 0
+          protocol    = "-1"
+          self        = true
+          description = "Allow unrestricted traffic within this security group"
         }
       }
       egress_rules = {
         "rule1" = {
-          from_port   = 0
-          to_port     = 0
           protocol    = "-1"
           cidr_ipv4   = "0.0.0.0/0"
           cidr_ipv6   = "::/0"
-          self        = true
-          description = "Example Rule 2"
+          description = "Example Rule 1"
         }
       }
     }

--- a/aws/security-group/security-group.tf
+++ b/aws/security-group/security-group.tf
@@ -119,8 +119,8 @@ resource "aws_vpc_security_group_ingress_rule" "ingress_ipv4" {
 
   security_group_id = aws_security_group.this[each.value.security_group_name].id
 
-  from_port   = each.value.from_port
-  to_port     = each.value.to_port
+  from_port   = each.value.ip_protocol == "-1" ? -1 : each.value.from_port
+  to_port     = each.value.ip_protocol == "-1" ? -1 : each.value.to_port
   ip_protocol = each.value.ip_protocol
   cidr_ipv4   = each.value.cidr_ipv4
   description = each.value.description
@@ -138,8 +138,8 @@ resource "aws_vpc_security_group_ingress_rule" "ingress_ipv6" {
 
   security_group_id = aws_security_group.this[each.value.security_group_name].id
 
-  from_port   = each.value.from_port
-  to_port     = each.value.to_port
+  from_port   = each.value.ip_protocol == "-1" ? -1 : each.value.from_port
+  to_port     = each.value.ip_protocol == "-1" ? -1 : each.value.to_port
   ip_protocol = each.value.ip_protocol
   cidr_ipv6   = each.value.cidr_ipv6
   description = each.value.description
@@ -177,8 +177,8 @@ resource "aws_vpc_security_group_egress_rule" "egress_ipv4" {
 
   security_group_id = aws_security_group.this[each.value.security_group_name].id
 
-  from_port   = each.value.from_port
-  to_port     = each.value.to_port
+  from_port   = each.value.ip_protocol == "-1" ? -1 : each.value.from_port
+  to_port     = each.value.ip_protocol == "-1" ? -1 : each.value.to_port
   ip_protocol = each.value.ip_protocol
   cidr_ipv4   = each.value.cidr_ipv4
   description = each.value.description
@@ -196,8 +196,8 @@ resource "aws_vpc_security_group_egress_rule" "egress_ipv6" {
 
   security_group_id = aws_security_group.this[each.value.security_group_name].id
 
-  from_port   = each.value.from_port
-  to_port     = each.value.to_port
+  from_port   = each.value.ip_protocol == "-1" ? -1 : each.value.from_port
+  to_port     = each.value.ip_protocol == "-1" ? -1 : each.value.to_port
   ip_protocol = each.value.ip_protocol
   cidr_ipv6   = each.value.cidr_ipv6
   description = each.value.description


### PR DESCRIPTION
## Summary
<!--- Add some bells and whistles for PR template. --->

- Updated the logic to set from_port and to_port to -1 when the IP protocol is "-1", ensuring compatibility for security group rules with all protocols. 

![image](https://github.com/user-attachments/assets/807783e1-60ab-4017-a472-170dbf889007)

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply --->
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 🕷 Bug fix (non-breaking change which fixes an issue)
- [ ] 👏 Performance optimization (non-breaking change which addresses a performance issue)
- [x] 🛠 Refactor (non-breaking change which does not change existing behavior or add new functionality)
- [ ] 📗 Library update (non-breaking change that will update one or more libraries to newer versions)
- [ ] 📝 Documentation (non-breaking change that doesn't change code behavior, can skip testing)
- [ ] ✅ Test (non-breaking change related to testing)
- [ ] 🔒 Security awareness (changes that effect permission scope, security scenarios)

## Test Plan
Terraform Plan

## Related Issues
N/A
