### PR TITLE
aws/jenkins: Add viewer group and config map name variables

### DIFF
--- a/aws/eks-helm/jenkins/CHANGELOG.md
+++ b/aws/eks-helm/jenkins/CHANGELOG.md
@@ -1,7 +1,12 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [0.1.34]() (2024-01-02)
+### Features
+* Add variable `jenkins_config_map_name` to use configMapRef in containerEnvFrom
+* Add variable `jenkins_viewer` to add permission for GitHub team groups that defined in jenkins viewer
 
 ## [0.1.31]() (2024-12-30)
 ### Features
 * Init module with all the code
+

--- a/aws/eks-helm/jenkins/README.md
+++ b/aws/eks-helm/jenkins/README.md
@@ -65,6 +65,7 @@ No modules.
 | <a name="input_jenkins_base_agent_image_name"></a> [jenkins\_base\_agent\_image\_name](#input\_jenkins\_base\_agent\_image\_name) | The base image for Jenkins agents | `string` | n/a | yes |
 | <a name="input_jenkins_base_agent_image_repo"></a> [jenkins\_base\_agent\_image\_repo](#input\_jenkins\_base\_agent\_image\_repo) | The base image for Jenkins agents | `string` | n/a | yes |
 | <a name="input_jenkins_base_agent_image_tag"></a> [jenkins\_base\_agent\_image\_tag](#input\_jenkins\_base\_agent\_image\_tag) | The base image for Jenkins agents | `string` | n/a | yes |
+| <a name="input_jenkins_config_map_name"></a> [jenkins\_config\_map\_name](#input\_jenkins\_config\_map\_name) | Jenkins config map name | `string` | `null` | no |
 | <a name="input_jenkins_cpu"></a> [jenkins\_cpu](#input\_jenkins\_cpu) | The CPU request and limit for Jenkins | `string` | `"1950m"` | no |
 | <a name="input_jenkins_dns_name"></a> [jenkins\_dns\_name](#input\_jenkins\_dns\_name) | The Jenkins DNS name | `string` | `"jenkins"` | no |
 | <a name="input_jenkins_env_var"></a> [jenkins\_env\_var](#input\_jenkins\_env\_var) | Jenkins environment variables | `string` | `null` | no |
@@ -72,6 +73,7 @@ No modules.
 | <a name="input_jenkins_fqdn"></a> [jenkins\_fqdn](#input\_jenkins\_fqdn) | FQDN of Jenkins service | `string` | `""` | no |
 | <a name="input_jenkins_memory"></a> [jenkins\_memory](#input\_jenkins\_memory) | The memory request and limit for Jenkins | `string` | `"4.5Gi"` | no |
 | <a name="input_jenkins_shared_lib_repo"></a> [jenkins\_shared\_lib\_repo](#input\_jenkins\_shared\_lib\_repo) | The Jenkins shared library repo | `string` | n/a | yes |
+| <a name="input_jenkins_viewer"></a> [jenkins\_viewer](#input\_jenkins\_viewer) | List of Jenkins viewer | `list(string)` | `[]` | no |
 | <a name="input_kaniko_version"></a> [kaniko\_version](#input\_kaniko\_version) | Version of Kaniko build tool | `string` | `"v1.21.1"` | no |
 | <a name="input_name"></a> [name](#input\_name) | n/a | `string` | `"jenkins"` | no |
 | <a name="input_namespace"></a> [namespace](#input\_namespace) | Namespace to install Jenkins. Default is jenkins | `string` | `"jenkins"` | no |

--- a/aws/eks-helm/jenkins/main.tf
+++ b/aws/eks-helm/jenkins/main.tf
@@ -67,12 +67,12 @@ controller:
                   - string:
                       id: "slack-bot-token"
                       scope: GLOBAL
-                      secret: "${var.slack_bot_token}"
+                      secret: "${sensitive(var.slack_bot_token)}"
                   %{endif}
                   %{for config in local.general_secret_configs}
                   - string:
                       id: "${config.secret_key}"
-                      secret: "${config.secret_value}"
+                      secret: "${sensitive(config.secret_value)}"
                       scope: GLOBAL
                   %{endfor}
       general: |-

--- a/aws/eks-helm/jenkins/main.tf
+++ b/aws/eks-helm/jenkins/main.tf
@@ -218,6 +218,14 @@ controller:
                       - "View/Read"
                       - "Run/Replay"
               %{endfor}
+              %{for team in var.jenkins_viewer}
+                - group:
+                    name: "${team}"
+                    permissions:
+                      - "Overall/Read"
+                      - "Job/Read"
+                      - "View/Read"
+              %{endfor}
           %{endif}
     %{if var.enabled_github_app_login}
     securityRealm: |-
@@ -278,10 +286,17 @@ controller:
         }
       ]
   %{endif}
-  %{if var.jenkins_env_var != null}
+  %{if var.jenkins_env_var != null || var.jenkins_config_map_name != null}
   containerEnvFrom:
+    %{if var.jenkins_config_map_name != null}
+    - configMapRef:
+        name: ${var.jenkins_config_map_name}
+    %{endif}
+
+    %{if var.jenkins_env_var != null}
     - secretRef:
         name: ${var.jenkins_env_var}
+    %{endif}
   %{endif}
   containerEnv:
     - name: DD_ENV

--- a/aws/eks-helm/jenkins/variables.tf
+++ b/aws/eks-helm/jenkins/variables.tf
@@ -51,6 +51,12 @@ variable "jenkins_executors" {
   description = "List of Jenkins executors"
 }
 
+variable "jenkins_viewer" {
+  description = "List of Jenkins viewer"
+  type        = list(string)
+  default     = []
+}
+
 variable "jenkins_shared_lib_repo" {
   description = "The Jenkins shared library repo"
   type        = string
@@ -278,6 +284,12 @@ variable "enabled_dark_them" {
 
 variable "jenkins_env_var" {
   description = "Jenkins environment variables"
+  type        = string
+  default     = null
+}
+
+variable "jenkins_config_map_name" {
+  description = "Jenkins config map name"
   type        = string
   default     = null
 }


### PR DESCRIPTION
## Summary
* Add variable `jenkins_config_map_name` to use configMapRef in containerEnvFrom
* Add variable `jenkins_viewer` to add permission for GitHub team groups that defined in jenkins viewer
* <!--- Add some bells and whistles for PR template. --->

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply --->
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 🕷 Bug fix (non-breaking change which fixes an issue)
- [ ] 👏 Performance optimization (non-breaking change which addresses a performance issue)
- [ ] 🛠 Refactor (non-breaking change which does not change existing behavior or add new functionality)
- [ ] 📗 Library update (non-breaking change that will update one or more libraries to newer versions)
- [ ] 📝 Documentation (non-breaking change that doesn't change code behavior, can skip testing)
- [ ] ✅ Test (non-breaking change related to testing)
- [ ] 🔒 Security awareness (changes that effect permission scope, security scenarios)

## Test Plan
<!--- Please input steps on how to test this PR, including evidence in the form of captured images or videos. If this is not necessary, provide the reason why. --->

## Related Issues
https://www.notion.so/c0x12c/Infra-Rollout-the-new-Terraform-modules-Helm-to-Regimen-16401fb05bf1803ca209e1a7c0a96520?pvs=4
<!--- Add a reference section for management tickets, and relevant conversations. --->
