### PR TITLE
fix index variables because of its count set

### DIFF
--- a/aws/oidc/provider/CHANGELOG.md
+++ b/aws/oidc/provider/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [0.1.40]() (2024-01-08)
+### Bug fixes
+* Fix `data.tls_certificate.this` use index because of it has "count" set
+
 ## [0.1.39]() (2024-01-08)
 ### Bug fixes
 * Update `var.create_provider` for `aws_iam_openid_connect_provider` to prevent bugs from not found

--- a/aws/oidc/provider/main.tf
+++ b/aws/oidc/provider/main.tf
@@ -27,5 +27,5 @@ resource "aws_iam_openid_connect_provider" "this" {
 
   url             = var.url
   client_id_list  = var.client_id_list
-  thumbprint_list = distinct(concat([data.tls_certificate.this.certificates[0].sha1_fingerprint], var.additional_thumbprints))
+  thumbprint_list = distinct(concat([data.tls_certificate.this[0].certificates[0].sha1_fingerprint], var.additional_thumbprints))
 }


### PR DESCRIPTION
## Summary
Fix `data.tls_certificate.this` use index because of it has "count" set
<!--- Add some bells and whistles for PR template. --->

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply --->
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [x] 🕷 Bug fix (non-breaking change which fixes an issue)
- [ ] 👏 Performance optimization (non-breaking change which addresses a performance issue)
- [ ] 🛠 Refactor (non-breaking change which does not change existing behavior or add new functionality)
- [ ] 📗 Library update (non-breaking change that will update one or more libraries to newer versions)
- [ ] 📝 Documentation (non-breaking change that doesn't change code behavior, can skip testing)
- [ ] ✅ Test (non-breaking change related to testing)
- [ ] 🔒 Security awareness (changes that effect permission scope, security scenarios)

## Test Plan
<!--- Please input steps on how to test this PR, including evidence in the form of captured images or videos. If this is not necessary, provide the reason why. --->

## Related Issues
<!--- Add a reference section for management tickets, and relevant conversations. --->
