### PR TITLE
Set Neo4j auth secret and update ingress HTTP port

### DIFF
--- a/aws/eks-helm/neo4j/CHANGELOG.md
+++ b/aws/eks-helm/neo4j/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [0.1.49]() (2025-01-10)
+### Features
+* Set Neo4j auth secret and update ingress HTTP port
+
 ## [0.1.38]() (2025-01-07)
 ### Features
 * Init module with all the code

--- a/aws/eks-helm/neo4j/README.md
+++ b/aws/eks-helm/neo4j/README.md
@@ -9,7 +9,9 @@ for persistent storage and various Kubernetes and Helm configurations.
 
 ```hcl
 module "neo4j" {
-  source = "github.com/spartan-stratos/terraform-modules//aws/eks-helm/neo4j?ref=v0.1.38"
+  source = "github.com/spartan-stratos/terraform-modules//aws/eks-helm/neo4j?ref=v0.1.49"
+  
+  domain = "example.com"
   efs_id = "example-id"
 }
 

--- a/aws/eks-helm/neo4j/examples/complete/main.tf
+++ b/aws/eks-helm/neo4j/examples/complete/main.tf
@@ -1,4 +1,6 @@
 module "neo4j" {
   source = "../.."
+
   efs_id = "example-id"
+  domain = "example.com"
 }

--- a/aws/eks-helm/neo4j/main.tf
+++ b/aws/eks-helm/neo4j/main.tf
@@ -13,8 +13,6 @@ resources:
   limits:
     cpu: ${var.neo4j_cpu}
     memory: ${var.neo4j_memory}
-auth:
-  existingSecret: password
 ingress:
   enabled: true
   annotations:

--- a/aws/eks-helm/neo4j/main.tf
+++ b/aws/eks-helm/neo4j/main.tf
@@ -13,6 +13,8 @@ resources:
   limits:
     cpu: ${var.neo4j_cpu}
     memory: ${var.neo4j_memory}
+auth:
+  existingSecret: password
 ingress:
   enabled: true
   annotations:
@@ -20,7 +22,7 @@ ingress:
     kubernetes.io/ingress.class: ${var.ingress_class_name}
     alb.ingress.kubernetes.io/target-type: "ip"
     alb.ingress.kubernetes.io/scheme: "internet-facing"
-    alb.ingress.kubernetes.io/listen-ports: "[{\"HTTP\": 80}, {\"HTTPS\": 443}]"
+    alb.ingress.kubernetes.io/listen-ports: "[{\"HTTP\": 7474}, {\"HTTPS\": 443}]"
   hostname: ${local.neo4j_fqdn}
   path: /*
 service:
@@ -42,6 +44,11 @@ resource "helm_release" "neo4j" {
   namespace        = var.namespace
   force_update     = var.force_update
   timeout          = 1000
+
+  set {
+    name  = "auth.password"
+    value = local.neo4j_password
+  }
 
   values = [local.manifest]
 


### PR DESCRIPTION
## Summary
<!--- Add some bells and whistles for PR template. --->

- Added configuration to use an existing secret for Neo4j authentication and set a password.
- Modified the ingress HTTP port to 7474 to align with Neo4j default settings. 
- > These changes enhance security and ensure proper application behavior.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply --->
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 🕷 Bug fix (non-breaking change which fixes an issue)
- [ ] 👏 Performance optimization (non-breaking change which addresses a performance issue)
- [ ] 🛠 Refactor (non-breaking change which does not change existing behavior or add new functionality)
- [ ] 📗 Library update (non-breaking change that will update one or more libraries to newer versions)
- [ ] 📝 Documentation (non-breaking change that doesn't change code behavior, can skip testing)
- [ ] ✅ Test (non-breaking change related to testing)
- [ ] 🔒 Security awareness (changes that effect permission scope, security scenarios)

## Test Plan
Terraform Plan

## Related Issues
N/A
