### PR TITLE
feat: add the region variable as optional

### DIFF
--- a/aws/eks-helm/aws-load-balancer-controller/CHANGELOG.md
+++ b/aws/eks-helm/aws-load-balancer-controller/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [0.1.53]() (2025-01-13)
+# Features
+* Add region as optional, use the data source `aws_region` to get the region if it is null.
+
 ## [0.1.42]() (2025-01-09)
 # Features
 * Add new policy documents for chart versions and auto get policy version based on chart_version.

--- a/aws/eks-helm/aws-load-balancer-controller/README.md
+++ b/aws/eks-helm/aws-load-balancer-controller/README.md
@@ -25,24 +25,24 @@ module "aws_eks_lb" {
 
 - [Example](./examples/)
 
-<!-- BEGIN_TF_DOCS -->
+
 ## Requirements
 
-| Name | Version |
-|------|---------|
-| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9.8 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.75.0 |
-| <a name="requirement_helm"></a> [helm](#requirement\_helm) | >=2.16.1 |
-| <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 2.33 |
+| Name                                                                         | Version   |
+|------------------------------------------------------------------------------|-----------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform)    | >= 1.9.8  |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws)                      | >= 5.75.0 |
+| <a name="requirement_helm"></a> [helm](#requirement\_helm)                   | >=2.16.1  |
+| <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 2.33   |
 
 ## Providers
 
-| Name | Version |
-|------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.75.0 |
-| <a name="provider_helm"></a> [helm](#provider\_helm) | >=2.16.1 |
-| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | >= 2.33 |
-| <a name="provider_time"></a> [time](#provider\_time) | n/a |
+| Name                                                                   | Version   |
+|------------------------------------------------------------------------|-----------|
+| <a name="provider_aws"></a> [aws](#provider\_aws)                      | >= 5.75.0 |
+| <a name="provider_helm"></a> [helm](#provider\_helm)                   | >=2.16.1  |
+| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | >= 2.33   |
+| <a name="provider_time"></a> [time](#provider\_time)                   | n/a       |
 
 ## Modules
 
@@ -50,45 +50,45 @@ No modules.
 
 ## Resources
 
-| Name | Type |
-|------|------|
-| [aws_iam_policy.aws_load_balancer_controller](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
-| [aws_iam_role.aws_load_balancer_controller](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
-| [aws_iam_role_policy_attachment.aws_load_balancer_controller_attach](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
-| [helm_release.aws_load_balancer_controller](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
-| [kubernetes_ingress_v1.external_alb](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/ingress_v1) | resource |
-| [kubernetes_ingress_v1.internal_alb](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/ingress_v1) | resource |
-| [time_sleep.wait_for_aws_load_balancer_webhook_is_running](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/sleep) | resource |
+| Name                                                                                                                                                                          | Type        |
+|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
+| [aws_iam_policy.aws_load_balancer_controller](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy)                                         | resource    |
+| [aws_iam_role.aws_load_balancer_controller](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role)                                             | resource    |
+| [aws_iam_role_policy_attachment.aws_load_balancer_controller_attach](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment)  | resource    |
+| [helm_release.aws_load_balancer_controller](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release)                                             | resource    |
+| [kubernetes_ingress_v1.external_alb](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/ingress_v1)                                           | resource    |
+| [kubernetes_ingress_v1.internal_alb](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/ingress_v1)                                           | resource    |
+| [time_sleep.wait_for_aws_load_balancer_webhook_is_running](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/sleep)                                | resource    |
 | [aws_iam_policy_document.aws_load_balancer_controller_assume_role_policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region)                                                                   | data source |
 
 ## Inputs
 
-| Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
-| <a name="input_aws_load_balancer_controller_chart_version"></a> [aws\_load\_balancer\_controller\_chart\_version](#input\_aws\_load\_balancer\_controller\_chart\_version) | Helm chart version of AWS load balancer controller | `string` | `"1.9.2"` | no |
-| <a name="input_aws_load_balancer_controller_name"></a> [aws\_load\_balancer\_controller\_name](#input\_aws\_load\_balancer\_controller\_name) | Name of AWS load balancer controller name | `string` | `"aws-load-balancer-controller"` | no |
-| <a name="input_certificate_arn"></a> [certificate\_arn](#input\_certificate\_arn) | Certificate arn for aws load balancer controller | `list(string)` | n/a | yes |
-| <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name) | EKS Cluster name | `string` | n/a | yes |
-| <a name="input_enable_internal_alb"></a> [enable\_internal\_alb](#input\_enable\_internal\_alb) | Enable internal aws load balancer | `bool` | `false` | no |
-| <a name="input_external_group_name"></a> [external\_group\_name](#input\_external\_group\_name) | Group name of external aws load balancer | `string` | `"external"` | no |
-| <a name="input_idle_timeout"></a> [idle\_timeout](#input\_idle\_timeout) | The idle timeout of load balancer. | `string` | `"60"` | no |
-| <a name="input_ingress_controller_service_name"></a> [ingress\_controller\_service\_name](#input\_ingress\_controller\_service\_name) | Service name of nginx ingress controller | `string` | `"ingress-nginx-controller"` | no |
-| <a name="input_internal_group_name"></a> [internal\_group\_name](#input\_internal\_group\_name) | Group name of internal aws load balancer | `string` | `"internal"` | no |
-| <a name="input_load_balancer_type"></a> [load\_balancer\_type](#input\_load\_balancer\_type) | Namespace of ingress controller | `string` | `"alb"` | no |
-| <a name="input_namespace"></a> [namespace](#input\_namespace) | Namespace of the aws load balancer | `string` | `"kube-system"` | no |
-| <a name="input_oidc_provider"></a> [oidc\_provider](#input\_oidc\_provider) | The OIDC provider which are realted to the cluster. | <pre>object({<br/>    arn = string<br/>    url = string<br/>  })</pre> | n/a | yes |
-| <a name="input_private_subnet"></a> [private\_subnet](#input\_private\_subnet) | List private subnet of cluster for creating aws internal load balancer | `list(string)` | n/a | yes |
-| <a name="input_public_subnet"></a> [public\_subnet](#input\_public\_subnet) | List public subnet of cluster for creating aws external load balancer | `list(string)` | n/a | yes |
-| <a name="input_region"></a> [region](#input\_region) | Region where the resources will be created. | `string` | n/a | yes |
-| <a name="input_ssl_policy"></a> [ssl\_policy](#input\_ssl\_policy) | SSL policy for AWS Load Balancer | `string` | `"ELBSecurityPolicy-TLS13-1-2-2021-06"` | no |
-| <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | ID of the VPC that the resources reside in. | `string` | n/a | yes |
+| Name                                                                                                                                                                       | Description                                                            | Type                                                                   | Default                                 | Required |
+|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------|------------------------------------------------------------------------|-----------------------------------------|:--------:|
+| <a name="input_aws_load_balancer_controller_chart_version"></a> [aws\_load\_balancer\_controller\_chart\_version](#input\_aws\_load\_balancer\_controller\_chart\_version) | Helm chart version of AWS load balancer controller                     | `string`                                                               | `"1.9.2"`                               |    no    |
+| <a name="input_aws_load_balancer_controller_name"></a> [aws\_load\_balancer\_controller\_name](#input\_aws\_load\_balancer\_controller\_name)                              | Name of AWS load balancer controller name                              | `string`                                                               | `"aws-load-balancer-controller"`        |    no    |
+| <a name="input_certificate_arn"></a> [certificate\_arn](#input\_certificate\_arn)                                                                                          | Certificate arn for aws load balancer controller                       | `list(string)`                                                         | n/a                                     |   yes    |
+| <a name="input_cluster_name"></a> [cluster\_name](#input\_cluster\_name)                                                                                                   | EKS Cluster name                                                       | `string`                                                               | n/a                                     |   yes    |
+| <a name="input_enable_internal_alb"></a> [enable\_internal\_alb](#input\_enable\_internal\_alb)                                                                            | Enable internal aws load balancer                                      | `bool`                                                                 | `false`                                 |    no    |
+| <a name="input_external_group_name"></a> [external\_group\_name](#input\_external\_group\_name)                                                                            | Group name of external aws load balancer                               | `string`                                                               | `"external"`                            |    no    |
+| <a name="input_idle_timeout"></a> [idle\_timeout](#input\_idle\_timeout)                                                                                                   | The idle timeout of load balancer.                                     | `string`                                                               | `"60"`                                  |    no    |
+| <a name="input_ingress_controller_service_name"></a> [ingress\_controller\_service\_name](#input\_ingress\_controller\_service\_name)                                      | Service name of nginx ingress controller                               | `string`                                                               | `"ingress-nginx-controller"`            |    no    |
+| <a name="input_internal_group_name"></a> [internal\_group\_name](#input\_internal\_group\_name)                                                                            | Group name of internal aws load balancer                               | `string`                                                               | `"internal"`                            |    no    |
+| <a name="input_load_balancer_type"></a> [load\_balancer\_type](#input\_load\_balancer\_type)                                                                               | Namespace of ingress controller                                        | `string`                                                               | `"alb"`                                 |    no    |
+| <a name="input_namespace"></a> [namespace](#input\_namespace)                                                                                                              | Namespace of the aws load balancer                                     | `string`                                                               | `"kube-system"`                         |    no    |
+| <a name="input_oidc_provider"></a> [oidc\_provider](#input\_oidc\_provider)                                                                                                | The OIDC provider which are realted to the cluster.                    | <pre>object({<br/>    arn = string<br/>    url = string<br/>  })</pre> | n/a                                     |   yes    |
+| <a name="input_private_subnet"></a> [private\_subnet](#input\_private\_subnet)                                                                                             | List private subnet of cluster for creating aws internal load balancer | `list(string)`                                                         | n/a                                     |   yes    |
+| <a name="input_public_subnet"></a> [public\_subnet](#input\_public\_subnet)                                                                                                | List public subnet of cluster for creating aws external load balancer  | `list(string)`                                                         | n/a                                     |   yes    |
+| <a name="input_region"></a> [region](#input\_region)                                                                                                                       | Region where the resources will be created.                            | `string`                                                               | `null`                                  |    no    |
+| <a name="input_ssl_policy"></a> [ssl\_policy](#input\_ssl\_policy)                                                                                                         | SSL policy for AWS Load Balancer                                       | `string`                                                               | `"ELBSecurityPolicy-TLS13-1-2-2021-06"` |    no    |
+| <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id)                                                                                                                     | ID of the VPC that the resources reside in.                            | `string`                                                               | n/a                                     |   yes    |
 
 ## Outputs
 
-| Name | Description |
-|------|-------------|
-| <a name="output_external_alb_cname"></a> [external\_alb\_cname](#output\_external\_alb\_cname) | CNAME address of external aws load balancer |
-| <a name="output_external_group_name"></a> [external\_group\_name](#output\_external\_group\_name) | Group name of external aws load balancer |
-| <a name="output_internal_alb_cname"></a> [internal\_alb\_cname](#output\_internal\_alb\_cname) | CNAME address of internal aws load balancer |
-| <a name="output_internal_group_name"></a> [internal\_group\_name](#output\_internal\_group\_name) | Group name of internal aws load balancer |
-<!-- END_TF_DOCS -->
+| Name                                                                                              | Description                                 |
+|---------------------------------------------------------------------------------------------------|---------------------------------------------|
+| <a name="output_external_alb_cname"></a> [external\_alb\_cname](#output\_external\_alb\_cname)    | CNAME address of external aws load balancer |
+| <a name="output_external_group_name"></a> [external\_group\_name](#output\_external\_group\_name) | Group name of external aws load balancer    |
+| <a name="output_internal_alb_cname"></a> [internal\_alb\_cname](#output\_internal\_alb\_cname)    | CNAME address of internal aws load balancer |
+| <a name="output_internal_group_name"></a> [internal\_group\_name](#output\_internal\_group\_name) | Group name of internal aws load balancer    |

--- a/aws/eks-helm/aws-load-balancer-controller/README.md
+++ b/aws/eks-helm/aws-load-balancer-controller/README.md
@@ -25,7 +25,7 @@ module "aws_eks_lb" {
 
 - [Example](./examples/)
 
-
+<!-- BEGIN_TF_DOCS -->
 ## Requirements
 
 | Name                                                                         | Version   |
@@ -92,3 +92,4 @@ No modules.
 | <a name="output_external_group_name"></a> [external\_group\_name](#output\_external\_group\_name) | Group name of external aws load balancer    |
 | <a name="output_internal_alb_cname"></a> [internal\_alb\_cname](#output\_internal\_alb\_cname)    | CNAME address of internal aws load balancer |
 | <a name="output_internal_group_name"></a> [internal\_group\_name](#output\_internal\_group\_name) | Group name of internal aws load balancer    |
+<!-- END_TF_DOCS -->

--- a/aws/eks-helm/aws-load-balancer-controller/data.tf
+++ b/aws/eks-helm/aws-load-balancer-controller/data.tf
@@ -1,0 +1,5 @@
+/**
+`aws_region` get the current region
+https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region
+ */
+data "aws_region" "current" {}

--- a/aws/eks-helm/aws-load-balancer-controller/locals.tf
+++ b/aws/eks-helm/aws-load-balancer-controller/locals.tf
@@ -6,4 +6,6 @@ locals {
   policy_document_version = "v2.${local.chart_version_parts[1]}"
 
   policy_file = "${path.module}/policies/AWSLoadBalancerControllerIAMPolicy-${local.policy_document_version}.json"
+
+  region = var.region != null ? var.region : data.aws_region.current.name
 }

--- a/aws/eks-helm/aws-load-balancer-controller/main.tf
+++ b/aws/eks-helm/aws-load-balancer-controller/main.tf
@@ -30,7 +30,7 @@ resource "helm_release" "aws_load_balancer_controller" {
 
   set {
     name  = "region"
-    value = var.region
+    value = local.region
   }
 
   set {

--- a/aws/eks-helm/aws-load-balancer-controller/variables.tf
+++ b/aws/eks-helm/aws-load-balancer-controller/variables.tf
@@ -62,6 +62,7 @@ variable "ssl_policy" {
 variable "region" {
   type        = string
   description = "Region where the resources will be created."
+  default     = null
 }
 
 variable "idle_timeout" {


### PR DESCRIPTION
## Summary
Add the `region variable` as optional, the default is null. If it is null, get the region by using `data aws_region`

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply --->
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 🕷 Bug fix (non-breaking change which fixes an issue)
- [ ] 👏 Performance optimization (non-breaking change which addresses a performance issue)
- [ ] 🛠 Refactor (non-breaking change which does not change existing behavior or add new functionality)
- [ ] 📗 Library update (non-breaking change that will update one or more libraries to newer versions)
- [ ] 📝 Documentation (non-breaking change that doesn't change code behavior, can skip testing)
- [ ] ✅ Test (non-breaking change related to testing)
- [ ] 🔒 Security awareness (changes that effect permission scope, security scenarios)

## Test Plan
N/A

## Related Issues
https://www.notion.so/c0x12c/Terraform-Terraform-Modules-17901fb05bf180bda02bef71ebbed9f3?pvs=4