### PR TITLE
bug: fix auth token elasticache

### DIFF
--- a/aws/elasticache/CHANGELOG.md
+++ b/aws/elasticache/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.54]() (2025-01-13)
+
+### Bug Fixes
+
+* Fix `auth_token` is enabled if `transit_encryption_enabled` is true
+
 ## [0.1.43]() (2025-01-09)
 
 ### Features

--- a/aws/elasticache/README.md
+++ b/aws/elasticache/README.md
@@ -13,7 +13,7 @@ This module will create the following components:
 
 ```hcl
 module "elasticache" {
-  source  = "github.com/spartan-stratos/terraform-modules//aws/elasticache?ref=v0.1.0"
+  source  = "github.com/spartan-stratos/terraform-modules//aws/elasticache?ref=v0.1.54"
 
   cluster_name                           = "example"
   environment                            = "dev"

--- a/aws/elasticache/main.tf
+++ b/aws/elasticache/main.tf
@@ -3,6 +3,7 @@
 https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string
  */
 resource "random_string" "this" {
+  count            = var.transit_encryption_enabled ? 1 : 0
   length           = 32
   special          = true
   override_special = "!&#$^<>-"
@@ -47,6 +48,6 @@ resource "aws_elasticache_replication_group" "this" {
 
   # The following blocks specified only if (var.transit_encryption_enabled == true)
   transit_encryption_enabled = var.transit_encryption_enabled
-  auth_token                 = random_string.this.result
+  auth_token                 = var.transit_encryption_enabled ? random_string.this[0].result : null
   auth_token_update_strategy = "ROTATE"
 }

--- a/aws/elasticache/outputs.tf
+++ b/aws/elasticache/outputs.tf
@@ -20,5 +20,5 @@ output "elasticache_replication_group_port" {
 
 output "transition_encryption_auth_token" {
   description = "The authentication token for enabling encryption in transit for the ElastiCache replication group. This token is used to secure client-to-node and node-to-node communications."
-  value       = random_string.this.result
+  value       = try(random_string.this[0].result, null)
 }


### PR DESCRIPTION
## Summary
Disable the Auth Token if `transit_encryption_enabled` is false
```
╷
│ Error: modifying ElastiCache Replication Group (service-platform) authentication: operation error ElastiCache: ModifyReplicationGroup, https response error StatusCode: 400, RequestID: 7ddae6b8-897f-4c7d-86f1-1c80f756b424, InvalidParameterValue: The AUTH token modification is only supported when encryption-in-transit is enabled.
│ 
│   with module.service_platform.module.redis.aws_elasticache_replication_group.this,
│   on .terraform/modules/service_platform.redis/aws/elasticache/main.tf line 26, in resource "aws_elasticache_replication_group" "this":
│   26: resource "aws_elasticache_replication_group" "this" {
│ 
╵

```

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply --->
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [x] 🕷 Bug fix (non-breaking change which fixes an issue)
- [ ] 👏 Performance optimization (non-breaking change which addresses a performance issue)
- [ ] 🛠 Refactor (non-breaking change which does not change existing behavior or add new functionality)
- [ ] 📗 Library update (non-breaking change that will update one or more libraries to newer versions)
- [ ] 📝 Documentation (non-breaking change that doesn't change code behavior, can skip testing)
- [ ] ✅ Test (non-breaking change related to testing)
- [ ] 🔒 Security awareness (changes that effect permission scope, security scenarios)

## Test Plan
<!--- Please input steps on how to test this PR, including evidence in the form of captured images or videos. If this is not necessary, provide the reason why. --->

## Related Issues
https://www.notion.so/c0x12c/Terraform-Terraform-Modules-17901fb05bf180bda02bef71ebbed9f3?pvs=4