### PR TITLE
Add Terraform module for GitHub Actions self-hosted runner

### DIFF
--- a/aws/github-self-hosted-runners/CHANGELOG.md
+++ b/aws/github-self-hosted-runners/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [0.1.59]() (2025-01-21)
+
+### Features
+
+- Initial implementation of Github Actions Self Hosted Runner on AWS EC2

--- a/aws/github-self-hosted-runners/README.md
+++ b/aws/github-self-hosted-runners/README.md
@@ -1,0 +1,77 @@
+# AWS Github Actions Self Hosted Runner
+
+Terraform module which creates resources for managing GitHub Actions Self-Hosted Runners on AWS.
+
+## Usage
+
+### Create Github Actions Self Hosted Runner
+
+```hcl
+module "github_self_host_runner" {
+  source = "github.com/spartan-stratos/terraform-modules//aws/github-self-host-runner?ref=v0.1.59"
+
+  github_actions_runner_registration_token = "example"
+  org_name                                 = "example"
+  security_group_ids = ["sg-1234567890abcdef0"]
+  vpc_zone_identifier = ["subnet-12345678", "subnet-87654321"]
+}
+```
+
+## Examples
+
+- [Example](./examples/complete/)
+
+<!-- BEGIN_TF_DOCS -->
+
+## Requirements
+
+| Name                                                                      | Version  |
+|---------------------------------------------------------------------------|----------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9.8 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws)                   | >= 5.75  |
+
+## Providers
+
+| Name                                              | Version |
+|---------------------------------------------------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.75 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name                                                                                                                        | Type     |
+|-----------------------------------------------------------------------------------------------------------------------------|----------|
+| [aws_autoscaling_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/autoscaling_group) | resource |
+| [aws_launch_template.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/launch_template)     | resource |
+
+## Inputs
+
+| Name                                                                                                                                                               | Description                                                                       | Type           | Default                         | Required |
+|--------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------|----------------|---------------------------------|:--------:|
+| <a name="input_ami"></a> [ami](#input\_ami)                                                                                                                        | The AMI ID for the EC2 instance used by the GitHub Runner.                        | `string`       | `"ami-00c257e12d6828491"`       |    no    |
+| <a name="input_desired_capacity"></a> [desired\_capacity](#input\_desired\_capacity)                                                                               | The desired number of EC2 instances in the Auto Scaling Group.                    | `number`       | `1`                             |    no    |
+| <a name="input_github_actions_runner_registration_token"></a> [github\_actions\_runner\_registration\_token](#input\_github\_actions\_runner\_registration\_token) | The token for registering the GitHub Runner with the GitHub Organization.         | `string`       | n/a                             |   yes    |
+| <a name="input_health_check_grace_period"></a> [health\_check\_grace\_period](#input\_health\_check\_grace\_period)                                                | The duration (in seconds) for the Auto Scaling Group's health check grace period. | `number`       | `600`                           |    no    |
+| <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type)                                                                                        | The EC2 instance type to use for the GitHub Runner.                               | `string`       | `"t3.micro"`                    |    no    |
+| <a name="input_max_size"></a> [max\_size](#input\_max\_size)                                                                                                       | The maximum number of EC2 instances in the Auto Scaling Group.                    | `number`       | `1`                             |    no    |
+| <a name="input_min_size"></a> [min\_size](#input\_min\_size)                                                                                                       | The minimum number of EC2 instances in the Auto Scaling Group.                    | `number`       | `1`                             |    no    |
+| <a name="input_org_name"></a> [org\_name](#input\_org\_name)                                                                                                       | The name of the GitHub Organization to register the GitHub Runner with.           | `string`       | n/a                             |   yes    |
+| <a name="input_runner_home"></a> [runner\_home](#input\_runner\_home)                                                                                              | The home directory for the GitHub Runner.                                         | `string`       | `"/home/ubuntu/actions-runner"` |    no    |
+| <a name="input_runner_labels"></a> [runner\_labels](#input\_runner\_labels)                                                                                        | Labels assigned to the GitHub Runner.                                             | `string`       | `"self-hosted,ec2"`             |    no    |
+| <a name="input_runner_version"></a> [runner\_version](#input\_runner\_version)                                                                                     | The version of the GitHub Runner software to be installed.                        | `string`       | `"2.321.0"`                     |    no    |
+| <a name="input_security_group_ids"></a> [security\_group\_ids](#input\_security\_group\_ids)                                                                       | The list of security group IDs.                                                   | `list(string)` | n/a                             |   yes    |
+| <a name="input_vpc_zone_identifier"></a> [vpc\_zone\_identifier](#input\_vpc\_zone\_identifier)                                                                    | The list of subnets for the EC2 instances of the Auto Scaling Group.              | `list(string)` | n/a                             |   yes    |
+
+## Outputs
+
+| Name                                                                                                                  | Description                     |
+|-----------------------------------------------------------------------------------------------------------------------|---------------------------------|
+| <a name="output_aws_autoscaling_group_arn"></a> [aws\_autoscaling\_group\_arn](#output\_aws\_autoscaling\_group\_arn) | ARN for this Auto Scaling Group |
+| <a name="output_aws_autoscaling_group_id"></a> [aws\_autoscaling\_group\_id](#output\_aws\_autoscaling\_group\_id)    | Auto Scaling Group id.          |
+| <a name="output_aws_launch_template_arn"></a> [aws\_launch\_template\_arn](#output\_aws\_launch\_template\_arn)       | The ARN of the launch template. |
+| <a name="output_aws_launch_template_id"></a> [aws\_launch\_template\_id](#output\_aws\_launch\_template\_id)          | The id of the launch template.  |
+
+<!-- END_TF_DOCS -->

--- a/aws/github-self-hosted-runners/examples/complete/README.md
+++ b/aws/github-self-hosted-runners/examples/complete/README.md
@@ -1,0 +1,11 @@
+# Github Actions Self Hosted Runner (Terraform) (EC2)
+
+## Usage
+
+To run this example you need to execute:
+
+```bash
+$ terraform init
+$ terraform plan
+$ terraform apply
+```

--- a/aws/github-self-hosted-runners/examples/complete/main.tf
+++ b/aws/github-self-hosted-runners/examples/complete/main.tf
@@ -1,0 +1,8 @@
+module "github_self_host_runner" {
+  source = "../../"
+
+  github_actions_runner_registration_token = "example"
+  org_name                                 = "example"
+  security_group_ids                       = ["sg-1234567890abcdef0"]
+  vpc_zone_identifier                      = ["subnet-12345678", "subnet-87654321"]
+}

--- a/aws/github-self-hosted-runners/examples/complete/outputs.tf
+++ b/aws/github-self-hosted-runners/examples/complete/outputs.tf
@@ -1,0 +1,19 @@
+output "aws_launch_template_arn" {
+  value       = module.github_self_host_runner.aws_launch_template_arn
+  description = "The ARN of the launch template."
+}
+
+output "aws_launch_template_id" {
+  value       = module.github_self_host_runner.aws_launch_template_id
+  description = "The id of the launch template."
+}
+
+output "aws_autoscaling_group_arn" {
+  value       = module.github_self_host_runner.aws_autoscaling_group_arn
+  description = "ARN for this Auto Scaling Group"
+}
+
+output "aws_autoscaling_group_id" {
+  value       = module.github_self_host_runner.aws_autoscaling_group_id
+  description = "Auto Scaling Group id."
+}

--- a/aws/github-self-hosted-runners/examples/complete/terraform.tf
+++ b/aws/github-self-hosted-runners/examples/complete/terraform.tf
@@ -1,0 +1,12 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "5.76.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = "us-west-2"
+}

--- a/aws/github-self-hosted-runners/main.tf
+++ b/aws/github-self-hosted-runners/main.tf
@@ -1,0 +1,28 @@
+resource "aws_launch_template" "this" {
+  name        = "github_runner_launch_template"
+  description = "Launch Template for GitHub Runners"
+
+  image_id               = var.ami
+  instance_type          = var.instance_type
+  vpc_security_group_ids = var.security_group_ids
+
+  user_data = base64encode(templatefile("${path.module}/scripts/bootstrap.tmpl", { GITHUB_ORG = var.org_name, GITHUB_ACTIONS_RUNNER_REGISTRATION_TOKEN = var.github_actions_runner_registration_token, RUNNER_VERSION = var.runner_version, RUNNER_HOME = var.runner_home, RUNNER_LABELS = var.runner_labels }))
+
+  tags = {
+    Name = "github_runner"
+  }
+}
+
+resource "aws_autoscaling_group" "this" {
+  name                      = "github_runners_autoscaling_group"
+  health_check_type         = "EC2"
+  health_check_grace_period = var.health_check_grace_period
+  desired_capacity          = var.desired_capacity
+  min_size                  = var.min_size
+  max_size                  = var.max_size
+  vpc_zone_identifier       = var.vpc_zone_identifier
+  launch_template {
+    id      = aws_launch_template.this.id
+    version = "$Latest"
+  }
+}

--- a/aws/github-self-hosted-runners/outputs.tf
+++ b/aws/github-self-hosted-runners/outputs.tf
@@ -1,0 +1,19 @@
+output "aws_launch_template_arn" {
+  value       = aws_launch_template.this.arn
+  description = "The ARN of the launch template."
+}
+
+output "aws_launch_template_id" {
+  value       = aws_launch_template.this.id
+  description = "The id of the launch template."
+}
+
+output "aws_autoscaling_group_arn" {
+  value       = aws_autoscaling_group.this.arn
+  description = "ARN for this Auto Scaling Group"
+}
+
+output "aws_autoscaling_group_id" {
+  value       = aws_autoscaling_group.this.id
+  description = "Auto Scaling Group id."
+}

--- a/aws/github-self-hosted-runners/scripts/bootstrap.tmpl
+++ b/aws/github-self-hosted-runners/scripts/bootstrap.tmpl
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+sudo apt update -y
+sudo apt install -y curl unzip jq
+
+sudo -u ubuntu bash <<EOF
+set -e
+
+mkdir -p ${RUNNER_HOME}
+cd ${RUNNER_HOME}
+
+curl -o actions-runner-linux-x64-${RUNNER_VERSION}.tar.gz -L \
+    https://github.com/actions/runner/releases/download/v${RUNNER_VERSION}/actions-runner-linux-x64-${RUNNER_VERSION}.tar.gz
+tar xzf actions-runner-linux-x64-${RUNNER_VERSION}.tar.gz
+
+./config.sh --url https://github.com/${GITHUB_ORG} --token ${GITHUB_ACTIONS_RUNNER_REGISTRATION_TOKEN} --labels ${RUNNER_LABELS} --unattended
+
+./run.sh
+EOF

--- a/aws/github-self-hosted-runners/variables.tf
+++ b/aws/github-self-hosted-runners/variables.tf
@@ -1,0 +1,73 @@
+variable "ami" {
+  description = "The AMI ID for the EC2 instance used by the GitHub Runner."
+  type        = string
+  default     = "ami-00c257e12d6828491"
+}
+
+variable "instance_type" {
+  description = "The EC2 instance type to use for the GitHub Runner."
+  type        = string
+  default     = "t3.micro"
+}
+
+variable "org_name" {
+  description = "The name of the GitHub Organization to register the GitHub Runner with."
+  type        = string
+}
+
+variable "github_actions_runner_registration_token" {
+  description = "The token for registering the GitHub Runner with the GitHub Organization."
+  type        = string
+}
+
+variable "runner_version" {
+  description = "The version of the GitHub Runner software to be installed."
+  default     = "2.321.0"
+  type        = string
+}
+
+variable "health_check_grace_period" {
+  description = "The duration (in seconds) for the Auto Scaling Group's health check grace period."
+  type        = number
+  default     = 600
+}
+
+variable "desired_capacity" {
+  description = "The desired number of EC2 instances in the Auto Scaling Group."
+  type        = number
+  default     = 1
+}
+
+variable "min_size" {
+  description = "The minimum number of EC2 instances in the Auto Scaling Group."
+  type        = number
+  default     = 1
+}
+
+variable "max_size" {
+  description = "The maximum number of EC2 instances in the Auto Scaling Group."
+  type        = number
+  default     = 1
+}
+
+variable "runner_home" {
+  description = "The home directory for the GitHub Runner."
+  type        = string
+  default     = "/home/ubuntu/actions-runner"
+}
+
+variable "runner_labels" {
+  description = "Labels assigned to the GitHub Runner."
+  type        = string
+  default     = "self-hosted,ec2"
+}
+
+variable "security_group_ids" {
+  description = "The list of security group IDs."
+  type        = list(string)
+}
+
+variable "vpc_zone_identifier" {
+  description = "The list of subnets for the EC2 instances of the Auto Scaling Group."
+  type        = list(string)
+}

--- a/aws/github-self-hosted-runners/versions.tf
+++ b/aws/github-self-hosted-runners/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.9.8"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.75"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
<!--- Add some bells and whistles for PR template. --->

- Introduce a new Terraform module to manage GitHub Actions self-hosted runners on AWS. 
- Includes resources for EC2 instances, launch templates, auto-scaling groups, and example usage. 

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply --->
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 🕷 Bug fix (non-breaking change which fixes an issue)
- [ ] 👏 Performance optimization (non-breaking change which addresses a performance issue)
- [ ] 🛠 Refactor (non-breaking change which does not change existing behavior or add new functionality)
- [ ] 📗 Library update (non-breaking change that will update one or more libraries to newer versions)
- [ ] 📝 Documentation (non-breaking change that doesn't change code behavior, can skip testing)
- [ ] ✅ Test (non-breaking change related to testing)
- [ ] 🔒 Security awareness (changes that effect permission scope, security scenarios)

## Test Plan
Terraform Plan

## Related Issues
https://app.vanta.com/tests/aws-kubernetes-cluster-control-plane-access-restricted
