### PR TITLE
bug: fix acm validation

### DIFF
--- a/aws/acm/CHANGELOG.md
+++ b/aws/acm/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.62]() (2025-01-24)
+
+### Features
+
+* Fix `validation_record_fqdns` value in `aws_acm_certificate_validation`.
+
 ## [0.1.12]() (2024-12-17)
 
 ### Features

--- a/aws/acm/README.md
+++ b/aws/acm/README.md
@@ -8,7 +8,7 @@ Terraform module which creates ACM certificates and validates them using Route53
 
 ```hcl
 module "acm" {
-  source  = "github.com/spartan-stratos/terraform-modules//aws/acm?ref=v0.1.0"
+  source  = "github.com/spartan-stratos/terraform-modules//aws/acm?ref=v0.1.62"
 
   zone_id                   = "example"
   domain_name               = "example.com"

--- a/aws/acm/main.tf
+++ b/aws/acm/main.tf
@@ -48,7 +48,7 @@ resource "aws_acm_certificate_validation" "this" {
 
   certificate_arn = aws_acm_certificate.this.arn
 
-  validation_record_fqdns = flatten([aws_route53_record.validation[*].fqdn])
+  validation_record_fqdns = [for record in aws_route53_record.validation : record.fqdn]
 
   timeouts {
     create = var.validation_timeout


### PR DESCRIPTION
## Summary
Update the ACM Validation `fqdn` value due to terraform apply issue
```
│ Error: Unsupported attribute
│ 
│   on .terraform/modules/backbone.acm/aws/acm/main.tf line 51, in resource "aws_acm_certificate_validation" "this":
│   51:   validation_record_fqdns = flatten([aws_route53_record.validation[*].fqdn])
│ 
│ This object does not have an attribute named "fqdn".
╵

```

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply --->
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [x] 🕷 Bug fix (non-breaking change which fixes an issue)
- [ ] 👏 Performance optimization (non-breaking change which addresses a performance issue)
- [ ] 🛠 Refactor (non-breaking change which does not change existing behavior or add new functionality)
- [ ] 📗 Library update (non-breaking change that will update one or more libraries to newer versions)
- [ ] 📝 Documentation (non-breaking change that doesn't change code behavior, can skip testing)
- [ ] ✅ Test (non-breaking change related to testing)
- [ ] 🔒 Security awareness (changes that effect permission scope, security scenarios)

## Test Plan
<!--- Please input steps on how to test this PR, including evidence in the form of captured images or videos. If this is not necessary, provide the reason why. --->

## Related Issues
N/A