### PR TITLE
Remove access_config block from EKS cluster

### DIFF
--- a/aws/eks-cluster/CHANGELOG.md
+++ b/aws/eks-cluster/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 All notable changes to this project will be documented in this file.
 
-
 ## [0.1.65]() (2025-02-05)
 
 ### Features

--- a/aws/eks-cluster/CHANGELOG.md
+++ b/aws/eks-cluster/CHANGELOG.md
@@ -2,10 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+
 ## [0.1.65]() (2025-02-05)
 
 ### Features
 * Add EKS access entries and API/config map authentication options
+* Remove deprecated access_config block from EKS cluster
 
 ## [0.1.59]() (2025-01-21)
 

--- a/aws/eks-cluster/cluster.tf
+++ b/aws/eks-cluster/cluster.tf
@@ -2,15 +2,6 @@ resource "aws_eks_cluster" "master" {
   name     = local.cluster_name
   role_arn = aws_iam_role.master.arn
 
-  access_config {
-    authentication_mode = (
-      var.enabled_config_map ? "CONFIG_MAP" :
-      var.enabled_api ? "API" :
-      var.enabled_api_and_config_map ? "API_AND_CONFIG_MAP" :
-      "CONFIG_MAP"
-    )
-  }
-
   vpc_config {
     security_group_ids      = concat(var.security_group_ids, tolist([aws_security_group.cluster.id]))
     subnet_ids              = concat(var.private_subnet_ids, var.public_subnet_ids)


### PR DESCRIPTION
## Summary
<!--- Add some bells and whistles for PR template. --->

- The access_config block should be removed because modifying this setting triggers the recreation of the EKS cluster, which is disruptive.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply --->
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [x] 🕷 Bug fix (non-breaking change which fixes an issue)
- [ ] 👏 Performance optimization (non-breaking change which addresses a performance issue)
- [ ] 🛠 Refactor (non-breaking change which does not change existing behavior or add new functionality)
- [ ] 📗 Library update (non-breaking change that will update one or more libraries to newer versions)
- [ ] 📝 Documentation (non-breaking change that doesn't change code behavior, can skip testing)
- [ ] ✅ Test (non-breaking change related to testing)
- [ ] 🔒 Security awareness (changes that effect permission scope, security scenarios)

## Test Plan
Terraform

## Related Issues
N/A
