### PR TITLE
Fix terraform installation syntax for ami

### DIFF
--- a/aws/github-self-hosted-runners/CHANGELOG.md
+++ b/aws/github-self-hosted-runners/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.66]() (2025-02-06)
+
+### Features
+- Update Terraform installation to allow version suffix support
+
 ## [0.1.65]() (2025-02-06)
 
 ### Features

--- a/aws/github-self-hosted-runners/scripts/setup-environment.tmpl
+++ b/aws/github-self-hosted-runners/scripts/setup-environment.tmpl
@@ -6,4 +6,4 @@ sudo apt install git-crypt
 curl -fsSL https://apt.releases.hashicorp.com/gpg | sudo apt-key add -
 sudo apt-add-repository "deb [arch=$(dpkg --print-architecture)] https://apt.releases.hashicorp.com $(lsb_release -cs) main"
 sudo apt update
-sudo apt install terraform=${TERRAFORM_VERSION}
+sudo apt install terraform=${TERRAFORM_VERSION}-*


### PR DESCRIPTION
## Summary
<!--- Add some bells and whistles for PR template. --->

- Previously, the script strictly installed the exact Terraform version. This update modifies the installation command to include version suffixes (which match with the syntax from version 1.4.3 and later)

https://developer.hashicorp.com/terraform/cli/install/apt#terraform-1-4-3-and-later

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply --->
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [x] 🕷 Bug fix (non-breaking change which fixes an issue)
- [ ] 👏 Performance optimization (non-breaking change which addresses a performance issue)
- [ ] 🛠 Refactor (non-breaking change which does not change existing behavior or add new functionality)
- [ ] 📗 Library update (non-breaking change that will update one or more libraries to newer versions)
- [ ] 📝 Documentation (non-breaking change that doesn't change code behavior, can skip testing)
- [ ] ✅ Test (non-breaking change related to testing)
- [ ] 🔒 Security awareness (changes that effect permission scope, security scenarios)

## Test Plan
Terraform Plan

## Related Issues
N/A
