### PR TITLE
Fix conditional assignment of response headers policy id in cloudFront distribution

### DIFF
--- a/aws/static-website/modules/cloudfront/main.tf
+++ b/aws/static-website/modules/cloudfront/main.tf
@@ -88,7 +88,7 @@ resource "aws_cloudfront_distribution" "this" {
       allowed_methods            = ordered_cache_behavior.value.allowed_methods
       cached_methods             = ordered_cache_behavior.value.cached_methods
       target_origin_id           = ordered_cache_behavior.value.target_origin_id
-      response_headers_policy_id = aws_cloudfront_response_headers_policy.this.id
+      response_headers_policy_id = var.enabled_response_headers_policy ? aws_cloudfront_response_headers_policy.this[0].id : null
 
       forwarded_values {
         query_string = ordered_cache_behavior.value.query_string


### PR DESCRIPTION
## Summary
<!--- Add some bells and whistles for PR template. --->
use `response_headers_policy_id = var.enabled_response_headers_policy ? aws_cloudfront_response_headers_policy[0].this.id : null` instead of assigning the resource id directly

### Why
<!--- Clearly define the issue or problem that your changes address. 
Describe what is currently not working as expected or what feature is missing. --->

### What
<!--- Provide a high-level overview of what has been modified, added, or removed in the codebase. 
This could include new features, bug fixes, refactoring efforts, or performance optimizations. --->

### Solution
<!--- Describe the architectural or design decisions you made while implementing the changes.
Explain the thought process behind your approach and how it aligns with best practices or existing patterns in the codebase. --->

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply --->
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 🕷 Bug fix (non-breaking change which fixes an issue)
- [ ] 👏 Performance optimization (non-breaking change which addresses a performance issue)
- [ ] 🛠 Refactor (non-breaking change which does not change existing behavior or add new functionality)
- [ ] 📗 Library update (non-breaking change that will update one or more libraries to newer versions)
- [ ] 📝 Documentation (non-breaking change that doesn't change code behavior, can skip testing)
- [ ] ✅ Test (non-breaking change related to testing)
- [ ] 🔒 Security awareness (changes that effect permission scope, security scenarios)

## Test Plan
<!--- Please input steps on how to test this PR, including evidence in the form of captured images or videos. If this is not necessary, provide the reason why. --->

## Related Issues
<!--- Add a reference section for management tickets, and relevant conversations. --->
