### PR TITLE
feat: allow to add more permission to s3 policy

### DIFF
--- a/aws/s3/CHANGELOG.md
+++ b/aws/s3/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [0.1.68]() (2025-02-20)
+
+### Features
+* Add `additional_actions` which allow s3 policy can be added permissions base on requirement of projects 
 
 ## [0.1.57]() (2025-01-15)
 

--- a/aws/s3/CHANGELOG.md
+++ b/aws/s3/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 ## [0.1.68]() (2025-02-20)
 
 ### Features
-* Add `additional_actions` which allow s3 policy can be added permissions base on requirement of projects 
+* Add `read_write_actions` which allow s3 policy can be added permissions base on requirement of projects
 
 ## [0.1.57]() (2025-01-15)
 

--- a/aws/s3/README.md
+++ b/aws/s3/README.md
@@ -36,7 +36,7 @@ module "s3" {
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.75 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.87.0 |
 
 ## Modules
 
@@ -72,7 +72,6 @@ module "s3" {
 | <a name="input_access_log_target_bucket_id"></a> [access\_log\_target\_bucket\_id](#input\_access\_log\_target\_bucket\_id) | The bucket ID to store the access logs | `string` | `null` | no |
 | <a name="input_access_log_target_prefix"></a> [access\_log\_target\_prefix](#input\_access\_log\_target\_prefix) | The target prefix for the access logs | `string` | `null` | no |
 | <a name="input_acl"></a> [acl](#input\_acl) | Canned ACL to apply to the bucket. Support private and public-read. | `string` | `"private"` | no |
-| <a name="input_additional_actions"></a> [additional\_actions](#input\_additional\_actions) | Additional actions for read\_write policy | `list(string)` | `[]` | no |
 | <a name="input_block_public_acls"></a> [block\_public\_acls](#input\_block\_public\_acls) | Whether Amazon S3 should block public ACLs for this bucket. | `bool` | `true` | no |
 | <a name="input_block_public_policy"></a> [block\_public\_policy](#input\_block\_public\_policy) | Whether Amazon S3 should block public bucket policies for this bucket. | `bool` | `true` | no |
 | <a name="input_bucket_name"></a> [bucket\_name](#input\_bucket\_name) | The bucket name to be created. | `string` | `null` | no |
@@ -91,6 +90,7 @@ module "s3" {
 | <a name="input_object_ownership"></a> [object\_ownership](#input\_object\_ownership) | Object ownership. Valid values: BucketOwnerPreferred, ObjectWriter or BucketOwnerEnforced | `string` | `null` | no |
 | <a name="input_public_policy_description"></a> [public\_policy\_description](#input\_public\_policy\_description) | Description for public policy | `string` | `"Policy that allows writing to the s3 public assets bucket"` | no |
 | <a name="input_public_policy_name_prefix"></a> [public\_policy\_name\_prefix](#input\_public\_policy\_name\_prefix) | The name prefix for the public policy | `string` | `"S3PublicAssetsWrite"` | no |
+| <a name="input_read_write_actions"></a> [read\_write\_actions](#input\_read\_write\_actions) | Read write policy actions | `list(string)` | <pre>[<br/>  "s3:DeleteObject",<br/>  "s3:GetObject",<br/>  "s3:GetObjectAcl",<br/>  "s3:ListBucket",<br/>  "s3:ObjectOwnerOverrideToBucketOwner",<br/>  "s3:PutObject",<br/>  "s3:PutObjectAcl"<br/>]</pre> | no |
 | <a name="input_read_write_policy_description"></a> [read\_write\_policy\_description](#input\_read\_write\_policy\_description) | Description for read write policy | `string` | `"Policy that allows writing to the S3 bucket"` | no |
 | <a name="input_read_write_policy_name_prefix"></a> [read\_write\_policy\_name\_prefix](#input\_read\_write\_policy\_name\_prefix) | The name prefix for the read write policy | `string` | `"S3ReadWrite"` | no |
 | <a name="input_readonly_policy_description"></a> [readonly\_policy\_description](#input\_readonly\_policy\_description) | Description for readonly policy | `string` | `"Policy that allows reading from the s3 assets bucket"` | no |

--- a/aws/s3/README.md
+++ b/aws/s3/README.md
@@ -72,6 +72,7 @@ module "s3" {
 | <a name="input_access_log_target_bucket_id"></a> [access\_log\_target\_bucket\_id](#input\_access\_log\_target\_bucket\_id) | The bucket ID to store the access logs | `string` | `null` | no |
 | <a name="input_access_log_target_prefix"></a> [access\_log\_target\_prefix](#input\_access\_log\_target\_prefix) | The target prefix for the access logs | `string` | `null` | no |
 | <a name="input_acl"></a> [acl](#input\_acl) | Canned ACL to apply to the bucket. Support private and public-read. | `string` | `"private"` | no |
+| <a name="input_additional_actions"></a> [additional\_actions](#input\_additional\_actions) | Additional actions for read\_write policy | `list(string)` | `[]` | no |
 | <a name="input_block_public_acls"></a> [block\_public\_acls](#input\_block\_public\_acls) | Whether Amazon S3 should block public ACLs for this bucket. | `bool` | `true` | no |
 | <a name="input_block_public_policy"></a> [block\_public\_policy](#input\_block\_public\_policy) | Whether Amazon S3 should block public bucket policies for this bucket. | `bool` | `true` | no |
 | <a name="input_bucket_name"></a> [bucket\_name](#input\_bucket\_name) | The bucket name to be created. | `string` | `null` | no |

--- a/aws/s3/iam.tf
+++ b/aws/s3/iam.tf
@@ -33,16 +33,8 @@ data "aws_iam_policy_document" "readonly_policy" {
 data "aws_iam_policy_document" "read_write_policy" {
   count = var.enabled_read_write_policy ? 1 : 0
   statement {
-    effect = "Allow"
-    actions = flatten(concat([
-      "s3:DeleteObject",
-      "s3:GetObject",
-      "s3:GetObjectAcl",
-      "s3:ListBucket",
-      "s3:ObjectOwnerOverrideToBucketOwner",
-      "s3:PutObject",
-      "s3:PutObjectAcl"
-    ], var.addtional_actions))
+    effect  = "Allow"
+    actions = var.read_write_actions
     resources = [
       local.bucket.arn,
       "${local.bucket.arn}/*"

--- a/aws/s3/iam.tf
+++ b/aws/s3/iam.tf
@@ -34,7 +34,7 @@ data "aws_iam_policy_document" "read_write_policy" {
   count = var.enabled_read_write_policy ? 1 : 0
   statement {
     effect = "Allow"
-    actions = [
+    actions = flatten(concat([
       "s3:DeleteObject",
       "s3:GetObject",
       "s3:GetObjectAcl",
@@ -42,7 +42,7 @@ data "aws_iam_policy_document" "read_write_policy" {
       "s3:ObjectOwnerOverrideToBucketOwner",
       "s3:PutObject",
       "s3:PutObjectAcl"
-    ]
+    ], var.addtional_actions))
     resources = [
       local.bucket.arn,
       "${local.bucket.arn}/*"

--- a/aws/s3/variables.tf
+++ b/aws/s3/variables.tf
@@ -109,10 +109,18 @@ variable "acl" {
   default     = "private"
 }
 
-variable "addtional_actions" {
-  description = "Additional actions for read_write policy"
+variable "read_write_actions" {
+  description = "Read write policy actions"
   type        = list(string)
-  default     = []
+  default = [
+    "s3:DeleteObject",
+    "s3:GetObject",
+    "s3:GetObjectAcl",
+    "s3:ListBucket",
+    "s3:ObjectOwnerOverrideToBucketOwner",
+    "s3:PutObject",
+    "s3:PutObjectAcl"
+  ]
 }
 
 # avoid recreating policies and their dependent resources during migration

--- a/aws/s3/variables.tf
+++ b/aws/s3/variables.tf
@@ -109,6 +109,12 @@ variable "acl" {
   default     = "private"
 }
 
+variable "addtional_actions" {
+  description = "Additional actions for read_write policy"
+  type        = list(string)
+  default     = []
+}
+
 # avoid recreating policies and their dependent resources during migration
 variable "read_write_policy_description" {
   description = "Description for read write policy"


### PR DESCRIPTION
## Summary
Allow to customize and add more policy for s3 read_write which can be required by different project
<!--- Add some bells and whistles for PR template. --->

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply --->
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 🕷 Bug fix (non-breaking change which fixes an issue)
- [ ] 👏 Performance optimization (non-breaking change which addresses a performance issue)
- [ ] 🛠 Refactor (non-breaking change which does not change existing behavior or add new functionality)
- [ ] 📗 Library update (non-breaking change that will update one or more libraries to newer versions)
- [ ] 📝 Documentation (non-breaking change that doesn't change code behavior, can skip testing)
- [ ] ✅ Test (non-breaking change related to testing)
- [ ] 🔒 Security awareness (changes that effect permission scope, security scenarios)

## Test Plan
<!--- Please input steps on how to test this PR, including evidence in the form of captured images or videos. If this is not necessary, provide the reason why. --->

## Related Issues
<!--- Add a reference section for management tickets, and relevant conversations. --->
