### PR TITLE
fix eks managed nodes: remove AmazonEKS_CNI_IPv6_Policy policy

### DIFF
--- a/aws/eks-cluster/CHANGELOG.md
+++ b/aws/eks-cluster/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.75]() (2025-03-07)
+
+### Fixes
+* Remove AmazonEKS_CNI_IPv6_Policy policy and policy attachments
+
 ## [0.1.74]() (2025-03-06)
 
 ### Fixes

--- a/aws/eks-cluster/modules/managed-node-group/iam.tf
+++ b/aws/eks-cluster/modules/managed-node-group/iam.tf
@@ -6,7 +6,6 @@ locals {
     eks_worker_node_policy                  = "${local.iam_role_policy_prefix}/AmazonEKSWorkerNodePolicy"
     ec2_container_registry_read_only_policy = "${local.iam_role_policy_prefix}/AmazonEC2ContainerRegistryReadOnly"
     ipv4_cni_policy                         = "${local.iam_role_policy_prefix}/AmazonEKS_CNI_Policy"
-    ipv6_cni_policy                         = "${local.iam_role_policy_prefix}/AmazonEKS_CNI_IPv6_Policy"
   }
 }
 


### PR DESCRIPTION
## Summary

Remove AmazonEKS_CNI_IPv6_Policy policy and policy attachments.

### Why

This AWS managed policy isn't present, or was deprecated. It's not on the official list https://docs.aws.amazon.com/aws-managed-policy/latest/reference/policy-list.html

### What

### Solution

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply --->
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [x] 🕷 Bug fix (non-breaking change which fixes an issue)
- [ ] 👏 Performance optimization (non-breaking change which addresses a performance issue)
- [ ] 🛠 Refactor (non-breaking change which does not change existing behavior or add new functionality)
- [ ] 📗 Library update (non-breaking change that will update one or more libraries to newer versions)
- [ ] 📝 Documentation (non-breaking change that doesn't change code behavior, can skip testing)
- [ ] ✅ Test (non-breaking change related to testing)
- [ ] 🔒 Security awareness (changes that effect permission scope, security scenarios)

## Test Plan

## Related Issues
https://www.notion.so/EKS-Managed-Nodes-Dev-Rollout-workloads-to-managed-nodes-1ab4e7d2715780f5932ac6556731dde3