### PR TITLE
Fix eks-cluster managed nodes

### DIFF
--- a/aws/eks-cluster/CHANGELOG.md
+++ b/aws/eks-cluster/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+
+## [0.1.77]() (2025-03-07)
+
+### Bug fixes
+* Managed nodes: only add iam role policy when there is at least 1 statemenet
+* Managed nodes: don't ignore desired_size
+
 ## [0.1.76]() (2025-03-07)
 * Add `service_accounts` variables to handle custom service account which will be a map with structure
 ```

--- a/aws/eks-cluster/CHANGELOG.md
+++ b/aws/eks-cluster/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [0.1.77]() (2025-03-07)
+## [0.1.78]() (2025-03-10)
 
 ### Bug fixes
 * Managed nodes: only add iam role policy when there is at least 1 statemenet

--- a/aws/eks-cluster/modules/managed-node-group/iam.tf
+++ b/aws/eks-cluster/modules/managed-node-group/iam.tf
@@ -89,6 +89,7 @@ data "aws_iam_policy_document" "role" {
 }
 
 resource "aws_iam_role_policy" "this" {
+  count       = length(var.iam_role_policy_statements) > 0 ? 1 : 0
   name        = var.iam_role_use_name_prefix ? null : local.iam_role_name
   name_prefix = var.iam_role_use_name_prefix ? "${local.iam_role_name}-" : null
   policy      = data.aws_iam_policy_document.role.json

--- a/aws/eks-cluster/modules/managed-node-group/main.tf
+++ b/aws/eks-cluster/modules/managed-node-group/main.tf
@@ -63,12 +63,6 @@ resource "aws_eks_node_group" "this" {
     }
   }
 
-  # lifecycle {
-  #   ignore_changes = [
-  #     scaling_config[0].desired_size,
-  #   ]
-  # }
-
   tags = merge(
     { "kubernetes.io/cluster/${var.cluster_name}" = "owned" },
     var.tags,

--- a/aws/eks-cluster/modules/managed-node-group/main.tf
+++ b/aws/eks-cluster/modules/managed-node-group/main.tf
@@ -63,11 +63,11 @@ resource "aws_eks_node_group" "this" {
     }
   }
 
-  lifecycle {
-    ignore_changes = [
-      scaling_config[0].desired_size,
-    ]
-  }
+  # lifecycle {
+  #   ignore_changes = [
+  #     scaling_config[0].desired_size,
+  #   ]
+  # }
 
   tags = merge(
     { "kubernetes.io/cluster/${var.cluster_name}" = "owned" },


### PR DESCRIPTION
## Summary

### Bug fixes
* Managed nodes: only add iam role policy when there is at least 1 statement
* Managed nodes: don't ignore desired_size

### Why
- Create IAM role policy error because there are no statements
- Couldn't update desired_size blocks us from update min_size and max_size because desired_size will not refresh and there is conditions ensure that min_size < desired_size < max_size. We don't need ignore_change because we don't refresh changes anyway.

### What


### Solution

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply --->
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [x] 🕷 Bug fix (non-breaking change which fixes an issue)
- [ ] 👏 Performance optimization (non-breaking change which addresses a performance issue)
- [ ] 🛠 Refactor (non-breaking change which does not change existing behavior or add new functionality)
- [ ] 📗 Library update (non-breaking change that will update one or more libraries to newer versions)
- [ ] 📝 Documentation (non-breaking change that doesn't change code behavior, can skip testing)
- [ ] ✅ Test (non-breaking change related to testing)
- [ ] 🔒 Security awareness (changes that affect permission scope, security scenarios)

## Test Plan

## Related Issues

https://www.notion.so/EKS-Managed-Nodes-Dev-Rollout-workloads-to-managed-nodes-1ab4e7d2715780f5932ac6556731dde3