### PR TITLE
fix: remove elasticache_cache_errors from aws_monitor

### DIFF
--- a/datadog/aws-monitor/CHANGELOG.md
+++ b/datadog/aws-monitor/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [0.1.80]() (2024-01-07)
+
+### Fix Bugs
+
+* Remove `elasticache_cache_errors` for elasticache monitor, which was not neccessary
+
 
 ## [0.1.38]() (2024-01-07)
 
@@ -16,7 +22,7 @@ All notable changes to this project will be documented in this file.
 
 ## [0.1.32]() (2024-12-31)
 
-### Bug fixes
+### Fixes
 
 * Add a default value for Terraform try functions
 

--- a/datadog/aws-monitor/elasticache.tf
+++ b/datadog/aws-monitor/elasticache.tf
@@ -79,21 +79,5 @@ locals {
       renotify_occurrences        = 3
       require_full_window         = false
     }
-
-    elasticache_cache_errors = {
-      priority_level = 3
-      title_tags     = "[High Cache Errors] [ElastiCache]"
-      title          = "Elasticache Cache Error is high"
-
-      query_template = "sum($${timeframe}):sum:aws.elasticache.cache_misses{environment:${var.environment}}.as_count() > $${threshold_critical}"
-      query_args = {
-        timeframe = "last_5m"
-      }
-
-      threshold_critical          = 15
-      threshold_critical_recovery = 0
-      renotify_interval           = 50
-      renotify_occurrences        = 3
-    }
   }
 }


### PR DESCRIPTION
## Summary
`elasticache_cache_errors` is not neccessary to monitor, which don't have value to monitor
<!--- Add some bells and whistles for PR template. --->

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply --->
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [x] 🕷 Bug fix (non-breaking change which fixes an issue)
- [ ] 👏 Performance optimization (non-breaking change which addresses a performance issue)
- [ ] 🛠 Refactor (non-breaking change which does not change existing behavior or add new functionality)
- [ ] 📗 Library update (non-breaking change that will update one or more libraries to newer versions)
- [ ] 📝 Documentation (non-breaking change that doesn't change code behavior, can skip testing)
- [ ] ✅ Test (non-breaking change related to testing)
- [ ] 🔒 Security awareness (changes that effect permission scope, security scenarios)

## Test Plan
<!--- Please input steps on how to test this PR, including evidence in the form of captured images or videos. If this is not necessary, provide the reason why. --->

## Related Issues
<!--- Add a reference section for management tickets, and relevant conversations. --->
