### PR TITLE
bug: add inline k8s service account annotations

### DIFF
--- a/aws/eks-service/CHANGELOG.md
+++ b/aws/eks-service/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.2.6]() (2025-03-29)
+
+### Bug fixes
+
+* Fix EKS service account annotations
+
 ## [0.1.71]() (2025-03-03)
 
 ### Bug fixes

--- a/aws/eks-service/README.md
+++ b/aws/eks-service/README.md
@@ -5,7 +5,7 @@ of  [Kubernetes and AWS resources](#resources).
 
 ```hcl
 module "keda" {
-  source = "github.com/spartan-stratos/terraform-modules//aws/eks-service?ref=v0.1.73"
+  source = "github.com/spartan-stratos/terraform-modules//aws/eks-service?ref=v0.2.6"
 
   cluster_name = "my-eks-cluster"
   eks_oidc_provider = {

--- a/aws/eks-service/main.tf
+++ b/aws/eks-service/main.tf
@@ -117,18 +117,8 @@ resource "kubernetes_service_account_v1" "this" {
   metadata {
     name      = var.service.service_account_name
     namespace = var.service.namespace
-  }
-}
-
-resource "kubernetes_annotations" "default" {
-  depends_on  = [kubernetes_namespace.this, kubernetes_service_account_v1.this]
-  api_version = "v1"
-  kind        = "ServiceAccount"
-  metadata {
-    name      = var.service.service_account_name
-    namespace = var.service.namespace
-  }
-  annotations = {
-    "eks.amazonaws.com/role-arn" = aws_iam_role.this.arn
+    annotations = {
+      "eks.amazonaws.com/role-arn" = aws_iam_role.this.arn
+    }
   }
 }


### PR DESCRIPTION
## Summary
Add the K8s service account annotation inline instead of separate to the `kubernetes_annotations`, it will help us remove the bug due to re-update the service account
## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply --->
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [x] 🕷 Bug fix (non-breaking change which fixes an issue)
- [ ] 👏 Performance optimization (non-breaking change which addresses a performance issue)
- [ ] 🛠 Refactor (non-breaking change which does not change existing behavior or add new functionality)
- [ ] 📗 Library update (non-breaking change that will update one or more libraries to newer versions)
- [ ] 📝 Documentation (non-breaking change that doesn't change code behavior, can skip testing)
- [ ] ✅ Test (non-breaking change related to testing)
- [ ] 🔒 Security awareness (changes that effect permission scope, security scenarios)

## Test Plan
- The Service account no have any changes when try to plan or apply

## Related Issues
N/A