### PR TITLE
feat: revert kubernetes_annotations for default service account

### DIFF
--- a/aws/eks-service/main.tf
+++ b/aws/eks-service/main.tf
@@ -113,6 +113,8 @@ resource "aws_iam_role_policy_attachment" "this" {
 }
 
 resource "kubernetes_service_account_v1" "this" {
+  depends_on = [kubernetes_namespace.this]
+
   count = var.service.create_service_account ? 1 : 0
   metadata {
     name      = var.service.service_account_name
@@ -120,5 +122,20 @@ resource "kubernetes_service_account_v1" "this" {
     annotations = {
       "eks.amazonaws.com/role-arn" = aws_iam_role.this.arn
     }
+  }
+}
+
+resource "kubernetes_annotations" "default" {
+  depends_on = [kubernetes_namespace.this]
+
+  count       = var.service.create_service_account ? 0 : 1
+  api_version = "v1"
+  kind        = "ServiceAccount"
+  metadata {
+    name      = var.service.service_account_name
+    namespace = var.service.namespace
+  }
+  annotations = {
+    "eks.amazonaws.com/role-arn" = aws_iam_role.this.arn
   }
 }


### PR DESCRIPTION
## Summary
Revert kubenetes_annotations due to the default service account 

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply --->
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [x] 🕷 Bug fix (non-breaking change which fixes an issue)
- [ ] 👏 Performance optimization (non-breaking change which addresses a performance issue)
- [ ] 🛠 Refactor (non-breaking change which does not change existing behavior or add new functionality)
- [ ] 📗 Library update (non-breaking change that will update one or more libraries to newer versions)
- [ ] 📝 Documentation (non-breaking change that doesn't change code behavior, can skip testing)
- [ ] ✅ Test (non-breaking change related to testing)
- [ ] 🔒 Security awareness (changes that effect permission scope, security scenarios)

## Test Plan
<!--- Please input steps on how to test this PR, including evidence in the form of captured images or videos. If this is not necessary, provide the reason why. --->

## Related Issues
N/A