### PR TITLE
fix: cloudtrail advance selector

### DIFF
--- a/aws/cloudtrail/CHANGELOG.md
+++ b/aws/cloudtrail/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.3.12]() (2024-12-20)
+
+### Bux fixes
+* Add advanced_event_selector to lifecycle ignore_changes
+
 ## [0.1.15]() (2024-12-20)
 
 ### Features

--- a/aws/cloudtrail/main.tf
+++ b/aws/cloudtrail/main.tf
@@ -108,8 +108,8 @@ resource "aws_cloudtrail" "this" {
 
   lifecycle {
     ignore_changes = [
-      # By default CloudTrail will create a default advanced event selector
-      # if not specified. This will cause a error when running terraform apply with refresh: terraform will try to delete the default advanced event selector
+      # By default AWS will create a default advanced event selector if not specified.
+      # This will cause a error when running terraform apply with refresh: terraform will try to delete the default advanced event selector
       advanced_event_selector,
     ]
   }


### PR DESCRIPTION
## Summary
Fix the bug that terraform trying to delete the default advance_events_selector when running with refresh=true.

### Why
By default AWS will create a default advanced event selector if not specified.
This will cause an error when running terraform apply with refresh: terraform will try to delete the default advanced event selector

### What
- Add the advance selector to lifecycle ignore_changes

### Solution

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply --->
- [x] ❌ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 🕷 Bug fix (non-breaking change which fixes an issue)
- [ ] 👏 Performance optimization (non-breaking change which addresses a performance issue)
- [ ] 🛠 Refactor (non-breaking change which does not change existing behavior or add new functionality)
- [ ] 📗 Library update (non-breaking change that will update one or more libraries to newer versions)
- [ ] 📝 Documentation (non-breaking change that doesn't change code behavior, can skip testing)
- [ ] ✅ Test (non-breaking change related to testing)
- [ ] 🔒 Security awareness (changes that effect permission scope, security scenarios)

## Test Plan
<!--- Please input steps on how to test this PR, including evidence in the form of captured images or videos. If this is not necessary, provide the reason why. --->

## Related Issues
https://www.notion.so/Reconcile-Terraform-to-remove-refresh-false-1c84e7d27157801ba19bd992b5055687