### PR TITLE
feat: update query template for pod restarts

### DIFF
--- a/datadog/service-monitor/CHANGELOG.md
+++ b/datadog/service-monitor/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [0.5.1]() (2024-01-05)
+
+### Features
+
+* Update restart datadog monitor being triggered by using diff function, which will check the increase restarting, for example if the pod restarted, the query template will count to 1, after that it will be 0 if there is no more increase in restart metrics.
+
 
 ## [0.1.36]() (2024-01-05)
 

--- a/datadog/service-monitor/CHANGELOG.md
+++ b/datadog/service-monitor/CHANGELOG.md
@@ -1,12 +1,11 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
-## [0.5.1]() (2024-01-05)
+## [0.5.1]() (2024-04-24)
 
 ### Features
 
-* Update restart datadog monitor being triggered by using diff function, which will check the increase restarting, for example if the pod restarted, the query template will count to 1, after that it will be 0 if there is no more increase in restart metrics.
-
+* Modify the Datadog restart monitor to use the diff function, which captures only new restart events. When a pod restarts, the query returns a value of 1, and it falls back to 0 if no further restarts occur.
 
 ## [0.1.36]() (2024-01-05)
 

--- a/datadog/service-monitor/CHANGELOG.md
+++ b/datadog/service-monitor/CHANGELOG.md
@@ -3,7 +3,7 @@
 All notable changes to this project will be documented in this file.
 ## [0.5.1]() (2024-04-24)
 
-### Features
+### Breaking changes
 
 * Modify the Datadog restart monitor to use the diff function, which captures only new restart events. When a pod restarts, the query returns a value of 1, and it falls back to 0 if no further restarts occur.
 

--- a/datadog/service-monitor/locals.tf
+++ b/datadog/service-monitor/locals.tf
@@ -18,6 +18,7 @@ locals {
 
     threshold_critical          = 1
     threshold_critical_recovery = 0
+    renotify_interval           = 60
   }
 
   default_cpu_monitors = {

--- a/datadog/service-monitor/locals.tf
+++ b/datadog/service-monitor/locals.tf
@@ -9,7 +9,9 @@ locals {
     title_tags     = "[Service Restarts]"
     title          = "Service ${var.service_name} restarted"
 
-    query_template = "avg($${timeframe}):monotonic_diff(sum:kubernetes.containers.restarts{kube_cluster_name:${var.cluster_name}, kube_service:${var.service_name}, kube_container_name:$${kube_container_name}} by {pod_name}.rollup(max, 300)) > $${threshold_critical}"
+    query_template = "avg($${timeframe}):monotonic_diff:kubernetes.containers.restarts{kube_cluster_name:${var.cluster_name}, kube_service:${var.service_name}, kube_container_name:$${kube_container_name}}.rollup(sum, 300) by {pod_name} > $${threshold_critical}"
+
+    
     query_args = {
       timeframe           = "last_5m"
       kube_container_name = var.overwrite_container_name != null ? var.overwrite_container_name : var.service_name

--- a/datadog/service-monitor/locals.tf
+++ b/datadog/service-monitor/locals.tf
@@ -9,7 +9,7 @@ locals {
     title_tags     = "[Service Restarts]"
     title          = "Service ${var.service_name} restarted"
 
-    query_template = "avg($${timeframe}):monotonic_diff(sum:kubernetes.containers.restarts{kube_cluster_name:${var.cluster_name}, kube_service:${var.service_name}, kube_container_name:$${kube_container_name}} by {pod_name}.rollup(max, 300))"
+    query_template = "avg($${timeframe}):monotonic_diff(sum:kubernetes.containers.restarts{kube_cluster_name:${var.cluster_name}, kube_service:${var.service_name}, kube_container_name:$${kube_container_name}} by {pod_name}.rollup(max, 300)) > $${threshold_critical}"
     query_args = {
       timeframe           = "last_5m"
       kube_container_name = var.overwrite_container_name != null ? var.overwrite_container_name : var.service_name

--- a/datadog/service-monitor/locals.tf
+++ b/datadog/service-monitor/locals.tf
@@ -9,7 +9,7 @@ locals {
     title_tags     = "[Service Restarts]"
     title          = "Service ${var.service_name} restarted"
 
-    query_template = "monotonic_diff(sum:kubernetes.containers.restarts{kube_cluster_name:${var.cluster_name}, kube_service:${var.service_name}, kube_container_name:$${kube_container_name}} by {pod_name}.rollup(max, 300))"
+    query_template = "avg($${timeframe}):monotonic_diff(sum:kubernetes.containers.restarts{kube_cluster_name:${var.cluster_name}, kube_service:${var.service_name}, kube_container_name:$${kube_container_name}} by {pod_name}.rollup(max, 300))"
     query_args = {
       timeframe           = "last_5m"
       kube_container_name = var.overwrite_container_name != null ? var.overwrite_container_name : var.service_name

--- a/datadog/service-monitor/locals.tf
+++ b/datadog/service-monitor/locals.tf
@@ -9,8 +9,7 @@ locals {
     title_tags     = "[Service Restarts]"
     title          = "Service ${var.service_name} restarted"
 
-    query_template = "avg($${timeframe}):monotonic_diff:kubernetes.containers.restarts{kube_cluster_name:${var.cluster_name}, kube_service:${var.service_name}, kube_container_name:$${kube_container_name}}.rollup(sum, 300) by {pod_name} > $${threshold_critical}"
-
+    query_template = "avg($${timeframe}):diff(sum:kubernetes.containers.restarts{kube_cluster_name:${var.cluster_name}, kube_service:${var.service_name}, kube_container_name:$${kube_container_name}} by {pod_name}.rollup(max, 300)) >= $${threshold_critical}"
     
     query_args = {
       timeframe           = "last_5m"
@@ -19,7 +18,6 @@ locals {
 
     threshold_critical          = 1
     threshold_critical_recovery = 0
-    renotify_interval           = 60
   }
 
   default_cpu_monitors = {

--- a/datadog/service-monitor/locals.tf
+++ b/datadog/service-monitor/locals.tf
@@ -9,7 +9,7 @@ locals {
     title_tags     = "[Service Restarts]"
     title          = "Service ${var.service_name} restarted"
 
-    query_template = "avg($${timeframe}):sum:kubernetes.containers.restarts{kube_cluster_name:${var.cluster_name}, kube_service:${var.service_name}, kube_container_name:$${kube_container_name}} by {pod_name} >= $${threshold_critical}"
+    query_template = "monotonic_diff(sum:kubernetes.containers.restarts{kube_cluster_name:${var.cluster_name}, kube_service:${var.service_name}, kube_container_name:$${kube_container_name}} by {pod_name}.rollup(max, 300))"
     query_args = {
       timeframe           = "last_5m"
       kube_container_name = var.overwrite_container_name != null ? var.overwrite_container_name : var.service_name


### PR DESCRIPTION
## Summary
Modify the Datadog restart monitor to use the diff function, which captures only new restart events. When a pod restarts, the query returns a value of 1, and it falls back to 0 if no further restarts occur.
<!--- Add some bells and whistles for PR template. --->

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply --->
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 🕷 Bug fix (non-breaking change which fixes an issue)
- [ ] 👏 Performance optimization (non-breaking change which addresses a performance issue)
- [ ] 🛠 Refactor (non-breaking change which does not change existing behavior or add new functionality)
- [ ] 📗 Library update (non-breaking change that will update one or more libraries to newer versions)
- [ ] 📝 Documentation (non-breaking change that doesn't change code behavior, can skip testing)
- [ ] ✅ Test (non-breaking change related to testing)
- [ ] 🔒 Security awareness (changes that effect permission scope, security scenarios)

## Test Plan
<img width="557" alt="image" src="https://github.com/user-attachments/assets/f456e225-bf83-410a-a4b8-7e5daf2cd4e0" />
<!--- Please input steps on how to test this PR, including evidence in the form of captured images or videos. If this is not necessary, provide the reason why. --->

## Related Issues
<!--- Add a reference section for management tickets, and relevant conversations. --->
