### PR TITLE
feat: add GCP PostgreSQL maintenance time

### DIFF
--- a/gcp/postgresql/CHANGELOG.md
+++ b/gcp/postgresql/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [0.6.3]() (2025-06-02)
+## [0.6.7]() (2025-06-06)
 
 ### Features
 

--- a/gcp/postgresql/CHANGELOG.md
+++ b/gcp/postgresql/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [0.6.7]() (2025-06-06)
+## [0.7.0]() (2025-06-16)
 
 ### Features
 

--- a/gcp/postgresql/CHANGELOG.md
+++ b/gcp/postgresql/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.6.3]() (2025-06-02)
+
+### Features
+
+* Add maintenance windows
+
 ## [0.1.4]() (2024-12-05)
 
 ### Features
@@ -13,4 +19,3 @@ All notable changes to this project will be documented in this file.
 ### Features
 
 * Initial commit with all the code
-

--- a/gcp/postgresql/README.md
+++ b/gcp/postgresql/README.md
@@ -39,17 +39,18 @@ module "postgresql" {
 
 ## Requirements
 
-| Name                                                                      | Version  |
-|---------------------------------------------------------------------------|----------|
+| Name | Version |
+|------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.9.8 |
-| <a name="requirement_google"></a> [google](#requirement\_google)          | \>= 6.12 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 6.12 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.6 |
 
 ## Providers
 
-| Name                                                       | Version  |
-|------------------------------------------------------------|----------|
-| <a name="provider_google"></a> [google](#provider\_google) | \>= 6.12 |
-| <a name="provider_random"></a> [random](#provider\_random) | \>= 3.6  |
+| Name | Version |
+|------|---------|
+| <a name="provider_google"></a> [google](#provider\_google) | >= 6.12 |
+| <a name="provider_random"></a> [random](#provider\_random) | >= 3.6 |
 
 ## Modules
 
@@ -57,53 +58,56 @@ No modules.
 
 ## Resources
 
-| Name                                                                                                                                                  | Type        |
-|-------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|
-| [google_compute_network.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/compute_network)                      | data source |
-| [google_sql_database_instance.primary](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/sql_database_instance)          | resource    |
-| [google_sql_database_instance.replica](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/sql_database_instance)          | resource    |
-| [google_sql_database_instance.analytic_replica](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/sql_database_instance) | resource    |
-| [google_sql_database.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/sql_database.html)                          | resource    |
-| [random_string.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/sql_database.html)                                | resource    |
-| [google_sql_user.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/sql_user)                                       | resource    |
+| Name | Type |
+|------|------|
+| [google_sql_database.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/sql_database) | resource |
+| [google_sql_database_instance.analytic_replica](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/sql_database_instance) | resource |
+| [google_sql_database_instance.primary](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/sql_database_instance) | resource |
+| [google_sql_database_instance.replica](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/sql_database_instance) | resource |
+| [google_sql_user.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/sql_user) | resource |
+| [random_string.this](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string) | resource |
+| [google_compute_network.this](https://registry.terraform.io/providers/hashicorp/google/latest/docs/data-sources/compute_network) | data source |
 
 ## Inputs
 
-| Name                                                                                                                                                     | Description                                                                                                                                                          | Type        | Default       | Required |
-|----------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------|---------------|:--------:|
-| <a name="input_project_id"></a> [project\_id](#input\_project\_id)                                                                                       | The ID of the project where the GKE will be created.                                                                                                                 | string      | n/a           |   yes    |
-| <a name="input_network_name"></a> [network\_name](#input\_network\_name)                                                                                 | The name of the network being created.                                                                                                                               | string      | n/a           |   yes    |
-| <a name="input_name"></a> [name](#input\_name)                                                                                                           | The prefix name of the Cloud SQL instance being created.                                                                                                             | string      | n/a           |   yes    |
-| <a name="input_db_name"></a> [db\_name](#input\_db\_name)                                                                                                | The name of database being created.                                                                                                                                  | string      | n/a           |   yes    |
-| <a name="input_region"></a> [region](#input\_region)                                                                                                     | The GCP Region to use for deployment.                                                                                                                                | string      | n/a           |   yes    |
-| <a name="input_size"></a> [size](#input\_size)                                                                                                           | Start size in GB.                                                                                                                                                    | number      | n/a           |   yes    |
-| <a name="input_tier"></a> [tier](#input\_tier)                                                                                                           | Database tier.                                                                                                                                                       | string      | `db-f1-micro` |    no    |
-| <a name="input_username"></a> [username](#input\_username)                                                                                               | The database username to get access.                                                                                                                                 | string      | n/a           |   yes    |
-| <a name="input_password"></a> [password](#input\_password)                                                                                               | The database password to get access.                                                                                                                                 | string      | `null`        |    no    |
-| <a name="input_availability_type"></a> [availability\_type](#input\_availability\_type)                                                                  | The availability type of the Cloud SQL instance, high availability (REGIONAL) or single zone (ZONAL).                                                                | string      | `ZONAL`       |    no    |
-| <a name="input_replica_count"></a> [replica_count](#input\_replica\_count)                                                                               | The number of Cloud SQL replicas to create.                                                                                                                          | number      | 0             |    no    |
-| <a name="input_analytic_replica_count"></a> [analytic\_replica\_count](#input\_analytic\_replica\_count)                                                 |                                                                                                                                                                      | number      | 0             |    no    |
-| <a name="input_labels"></a> [labels](#input\_labels)                                                                                                     | The resource labels to represent user provided metadata.                                                                                                             | map(string) | {}            |    no    |
-| <a name="input_database_flags"></a> [database\_flags](#input\_database\_flags)                                                                           | The Cloud SQL instance database flags to create.                                                                                                                     | map(string) | {}            |    no    |
-| <a name="input_enabled_deletion_protection"></a> [enabled\_deletion\_protection](#input\_enabled\_deletion\_protection)                                  | The boolean to specifies whether deletion protection should be enabled of disabled.                                                                                  | bool        | `true`        |    no    |
-| <a name="input_daily_sql_instance_backup_start_time"></a> [daily\_sql\_instance\_backup\_start\_time](#input\_daily\_sql\_instance\_backup\_start\_time) | The start time of daily Cloud SQL instance backup in format 'HH:MM' 24-hour UTC.                                                                                     | string      | `08:00`       |    no    |
-| <a name="input_retained_backups_count"></a> [retained\_backups\_count](#input\_retained\_backups\_count)                                                 | Depending on the value of retention_unit, this is used to determine if a backup needs to be deleted. If retention_unit is 'COUNT', we will retain this many backups. | number      | `7`           |    no    |
-| <a name="input_transaction_log_retention_days"></a> [transaction\_log\_retention\_days](#input\_transaction\_log\_retention\_days)                       | The number of days of transaction logs we retain for point in time restore, from 1-7 for standard instance.                                                          | number      | `7`           |    no    |
-| <a name="input_database_version"></a> [database\_version](#input\_database\_version)                                                                     | The Cloud SQL database version to use.                                                                                                                               | string      | `POSTGRES_16` |    no    |
-| <a name="input_enabled_disk_autoresize"></a> [enabled\_disk\_autoresize](#input\_enabled\_disk\_autoresize)                                              | Enables auto-resizing of the storage size. Defaults to true.                                                                                                         | bool        | `true`        |    no    |
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_analytic_replica_count"></a> [analytic\_replica\_count](#input\_analytic\_replica\_count) | The number of Cloud SQL analytic replicas to create. | `number` | `0` | no |
+| <a name="input_analytic_replica_maintenance_window"></a> [analytic\_replica\_maintenance\_window](#input\_analytic\_replica\_maintenance\_window) | Maintenance window configuration for analytic replica instances | <pre>object({<br/>    day          = number<br/>    hour         = number<br/>    update_track = string<br/>  })</pre> | <pre>{<br/>  "day": 1,<br/>  "hour": 8,<br/>  "update_track": "stable"<br/>}</pre> | no |
+| <a name="input_availability_type"></a> [availability\_type](#input\_availability\_type) | The availability type of the Cloud SQL instance, high availability (REGIONAL) or single zone (ZONAL). | `string` | `"ZONAL"` | no |
+| <a name="input_daily_sql_instance_backup_start_time"></a> [daily\_sql\_instance\_backup\_start\_time](#input\_daily\_sql\_instance\_backup\_start\_time) | The start time of daily Cloud SQL instance backup in format 'HH:MM' 24-hour UTC. | `string` | `"08:00"` | no |
+| <a name="input_database_flags"></a> [database\_flags](#input\_database\_flags) | The Cloud SQL instance database flags to create. | `map(string)` | `{}` | no |
+| <a name="input_database_version"></a> [database\_version](#input\_database\_version) | The Cloud SQL database version to use. | `string` | `"POSTGRES_16"` | no |
+| <a name="input_db_name"></a> [db\_name](#input\_db\_name) | The name of database being created. | `string` | n/a | yes |
+| <a name="input_enabled_deletion_protection"></a> [enabled\_deletion\_protection](#input\_enabled\_deletion\_protection) | The boolean to specifies whether deletion protection should be enabled of disabled. | `bool` | `true` | no |
+| <a name="input_enabled_disk_autoresize"></a> [enabled\_disk\_autoresize](#input\_enabled\_disk\_autoresize) | Enables auto-resizing of the storage size. Defaults to true. | `bool` | `true` | no |
+| <a name="input_labels"></a> [labels](#input\_labels) | The resource labels to represent user provided metadata. | `map(string)` | `{}` | no |
+| <a name="input_master_maintenance_window"></a> [master\_maintenance\_window](#input\_master\_maintenance\_window) | Maintenance window configuration for the master instance | <pre>object({<br/>    day          = number<br/>    hour         = number<br/>    update_track = string<br/>  })</pre> | <pre>{<br/>  "day": 1,<br/>  "hour": 9,<br/>  "update_track": "stable"<br/>}</pre> | no |
+| <a name="input_name"></a> [name](#input\_name) | The prefix name of the Cloud SQL instance being created. | `string` | n/a | yes |
+| <a name="input_network_name"></a> [network\_name](#input\_network\_name) | The name of the network being created. | `string` | n/a | yes |
+| <a name="input_password"></a> [password](#input\_password) | The database password to get access. | `string` | `null` | no |
+| <a name="input_project_id"></a> [project\_id](#input\_project\_id) | The ID of the project where the GKE will be created. | `string` | n/a | yes |
+| <a name="input_region"></a> [region](#input\_region) | The GCP Region to use for deployment. | `string` | n/a | yes |
+| <a name="input_replica_count"></a> [replica\_count](#input\_replica\_count) | The number of Cloud SQL replicas to create. | `number` | `0` | no |
+| <a name="input_replica_maintenance_window"></a> [replica\_maintenance\_window](#input\_replica\_maintenance\_window) | Maintenance window configuration for replica instances | <pre>object({<br/>    day          = number<br/>    hour         = number<br/>    update_track = string<br/>  })</pre> | <pre>{<br/>  "day": 1,<br/>  "hour": 8,<br/>  "update_track": "stable"<br/>}</pre> | no |
+| <a name="input_retained_backups_count"></a> [retained\_backups\_count](#input\_retained\_backups\_count) | Depending on the value of retention\_unit, this is used to determine if a backup needs to be deleted. If retention\_unit is 'COUNT', we will retain this many backups. | `number` | `7` | no |
+| <a name="input_size"></a> [size](#input\_size) | Start size in GB. | `number` | n/a | yes |
+| <a name="input_tier"></a> [tier](#input\_tier) | Database tier. | `string` | `"db-f1-micro"` | no |
+| <a name="input_transaction_log_retention_days"></a> [transaction\_log\_retention\_days](#input\_transaction\_log\_retention\_days) | The number of days of transaction logs we retain for point in time restore, from 1-7 for standard instance. | `number` | `7` | no |
+| <a name="input_username"></a> [username](#input\_username) | The database username to get access. | `string` | n/a | yes |
 
 ## Outputs
 
-| Name                                                                                                                                                                   | Description                                                                                                                |
-|------------------------------------------------------------------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------|
-| <a name="output_db_primary_private_ip_address"></a> [db\_primary\_private\_ip\_address](#output\_db\_primary\_private\_ip\_address)                                    | The private IP address of primary instance.                                                                                |
-| <a name="output_db_replica_private_ip_address"></a> [db\_replica\_private\_ip\_address](#output\_db\_replica\_private\_ip\_address)                                    | The list of private IP address of replica instance. If there is no replica, use the primary instance's private IP address. |
-| <a name="output_db_analytic_replica_private_ip_addresses"></a> [db\_analytic\_replica\_private\_ip\_addresses](#output\_db\_analytic\_replica\_private\_ip\_addresses) | The list of private IP address of analytic replica instance.                                                               |
-| <a name="output_db_primary_connection_name"></a> [db\_primary\_connection\_name](#output\_db\_primary\_connection\_name)                                               | The primary instance connection name.                                                                                      |
-| <a name="output_db_replica_connection_name"></a> [db\_replica\_connection\_name](#output\_db\_replica\_connection\_name)                                               | The list of replica(s) connection name.                                                                                    |
-| <a name="output_db_analytic_replica_connection_name"></a> [db\_analytic\_replica\_connection\_name](#output\_db\_analytic\_replica\_connection\_name)                  | The list of analytic replica(s) connection name.                                                                           |
-| <a name="output_db_username"></a> [db\_username](#output\_db\_username)                                                                                                | The database username.                                                                                                     |
-| <a name="output_db_password"></a> [db\_password](#output\_db\_password)                                                                                                | The database password.                                                                                                     |
-| <a name="output_db_name"></a> [db\_name](#output\_db\_name)                                                                                                            | The database name.                                                                                                         |
+| Name | Description |
+|------|-------------|
+| <a name="output_db_analytic_replica_connection_name"></a> [db\_analytic\_replica\_connection\_name](#output\_db\_analytic\_replica\_connection\_name) | The list of analytic replica(s) connection name. |
+| <a name="output_db_analytic_replica_private_ip_addresses"></a> [db\_analytic\_replica\_private\_ip\_addresses](#output\_db\_analytic\_replica\_private\_ip\_addresses) | The list of private IP address of analytic replica instance. |
+| <a name="output_db_name"></a> [db\_name](#output\_db\_name) | The database name. |
+| <a name="output_db_password"></a> [db\_password](#output\_db\_password) | The database password. |
+| <a name="output_db_primary_connection_name"></a> [db\_primary\_connection\_name](#output\_db\_primary\_connection\_name) | The primary instance connection name. |
+| <a name="output_db_primary_private_ip_address"></a> [db\_primary\_private\_ip\_address](#output\_db\_primary\_private\_ip\_address) | The private IP address of primary instance. |
+| <a name="output_db_replica_connection_name"></a> [db\_replica\_connection\_name](#output\_db\_replica\_connection\_name) | The list of replica(s) connection name. |
+| <a name="output_db_replica_private_ip_address"></a> [db\_replica\_private\_ip\_address](#output\_db\_replica\_private\_ip\_address) | The list of private IP address of replica instance. If there is no replica, use the primary instance's private IP address. |
+| <a name="output_db_username"></a> [db\_username](#output\_db\_username) | The database username. |
 
 <!-- END_TF_DOCS -->

--- a/gcp/postgresql/examples/complete/main.tf
+++ b/gcp/postgresql/examples/complete/main.tf
@@ -12,4 +12,19 @@ module "postgresql" {
 
   replica_count          = 1
   analytic_replica_count = 1
+  master_maintenance_window = {
+    day          = 1 # Monday
+    hour         = 9 # UTC
+    update_track = "stable"
+  }
+  replica_maintenance_window = {
+    day          = 1 # Monday
+    hour         = 8 # UTC
+    update_track = "stable"
+  }
+  analytic_replica_maintenance_window = {
+    day          = 1 # Monday
+    hour         = 8 # UTC
+    update_track = "stable"
+  }
 }

--- a/gcp/postgresql/examples/complete/main.tf
+++ b/gcp/postgresql/examples/complete/main.tf
@@ -14,7 +14,7 @@ module "postgresql" {
   analytic_replica_count = 1
   master_maintenance_window = {
     day          = 1 # Monday
-    hour         = 9 # UTC
+    hour         = 8 # UTC
     update_track = "stable"
   }
   replica_maintenance_window = {

--- a/gcp/postgresql/main.tf
+++ b/gcp/postgresql/main.tf
@@ -50,6 +50,12 @@ resource "google_sql_database_instance" "primary" {
         retained_backups = var.retained_backups_count
       }
     }
+
+    maintenance_window {
+      day          = var.master_maintenance_window.day
+      hour         = var.master_maintenance_window.hour
+      update_track = var.master_maintenance_window.update_track
+    }
   }
 
   lifecycle {
@@ -100,6 +106,12 @@ resource "google_sql_database_instance" "replica" {
         value = database_flags.value
       }
     }
+
+    maintenance_window {
+      day          = var.replica_maintenance_window.day
+      hour         = var.replica_maintenance_window.hour
+      update_track = var.replica_maintenance_window.update_track
+    }
   }
 
   lifecycle {
@@ -149,6 +161,12 @@ resource "google_sql_database_instance" "analytic_replica" {
         name  = database_flags.key
         value = database_flags.value
       }
+    }
+
+    maintenance_window {
+      day          = var.analytic_replica_maintenance_window.day
+      hour         = var.analytic_replica_maintenance_window.hour
+      update_track = var.analytic_replica_maintenance_window.update_track
     }
   }
 

--- a/gcp/postgresql/variables.tf
+++ b/gcp/postgresql/variables.tf
@@ -114,3 +114,45 @@ variable "enabled_disk_autoresize" {
   type        = bool
   default     = true
 }
+
+variable "master_maintenance_window" {
+  description = "Maintenance window configuration for the master instance"
+  type = object({
+    day          = number
+    hour         = number
+    update_track = string
+  })
+  default = {
+    day          = 1 # Monday
+    hour         = 9 # UTC
+    update_track = "stable"
+  }
+}
+
+variable "replica_maintenance_window" {
+  description = "Maintenance window configuration for replica instances"
+  type = object({
+    day          = number
+    hour         = number
+    update_track = string
+  })
+  default = {
+    day          = 1 # Monday
+    hour         = 8 # UTC
+    update_track = "stable"
+  }
+}
+
+variable "analytic_replica_maintenance_window" {
+  description = "Maintenance window configuration for analytic replica instances"
+  type = object({
+    day          = number
+    hour         = number
+    update_track = string
+  })
+  default = {
+    day          = 1 # Monday
+    hour         = 8 # UTC
+    update_track = "stable"
+  }
+}

--- a/gcp/postgresql/variables.tf
+++ b/gcp/postgresql/variables.tf
@@ -127,6 +127,19 @@ variable "master_maintenance_window" {
     hour         = 9 # UTC
     update_track = "stable"
   }
+
+  validation {
+    condition     = var.master_maintenance_window.day >= 1 && var.master_maintenance_window.day <= 7
+    error_message = "The 'day' attribute for maintenance_window must be between 1 (Monday) and 7 (Sunday)."
+  }
+  validation {
+    condition     = var.master_maintenance_window.hour >= 0 && var.master_maintenance_window.hour <= 23
+    error_message = "The 'hour' attribute for maintenance_window must be between 0 and 23 (UTC)."
+  }
+  validation {
+    condition     = contains(["week5", "stable", "canary"], var.master_maintenance_window.update_track)
+    error_message = "The 'update_track' attribute for maintenance_window must be either \"week5\", \"stable\" or \"canary\"."
+  }
 }
 
 variable "replica_maintenance_window" {
@@ -141,6 +154,19 @@ variable "replica_maintenance_window" {
     hour         = 8 # UTC
     update_track = "stable"
   }
+
+  validation {
+    condition     = var.replica_maintenance_window.day >= 1 && var.replica_maintenance_window.day <= 7
+    error_message = "The 'day' attribute for maintenance_window must be between 1 (Monday) and 7 (Sunday)."
+  }
+  validation {
+    condition     = var.replica_maintenance_window.hour >= 0 && var.replica_maintenance_window.hour <= 23
+    error_message = "The 'hour' attribute for maintenance_window must be between 0 and 23 (UTC)."
+  }
+  validation {
+    condition     = contains(["week5", "stable", "canary"], var.replica_maintenance_window.update_track)
+    error_message = "The 'update_track' attribute for maintenance_window must be either \"week5\", \"stable\" or \"canary\"."
+  }
 }
 
 variable "analytic_replica_maintenance_window" {
@@ -154,5 +180,18 @@ variable "analytic_replica_maintenance_window" {
     day          = 1 # Monday
     hour         = 8 # UTC
     update_track = "stable"
+  }
+
+  validation {
+    condition     = var.analytic_replica_maintenance_window.day >= 1 && var.analytic_replica_maintenance_window.day <= 7
+    error_message = "The 'day' attribute for maintenance_window must be between 1 (Monday) and 7 (Sunday)."
+  }
+  validation {
+    condition     = var.analytic_replica_maintenance_window.hour >= 0 && var.analytic_replica_maintenance_window.hour <= 23
+    error_message = "The 'hour' attribute for maintenance_window must be between 0 and 23 (UTC)."
+  }
+  validation {
+    condition     = contains(["week5", "stable", "canary"], var.analytic_replica_maintenance_window.update_track)
+    error_message = "The 'update_track' attribute for maintenance_window must be either \"week5\", \"stable\" or \"canary\"."
   }
 }

--- a/gcp/postgresql/variables.tf
+++ b/gcp/postgresql/variables.tf
@@ -124,7 +124,7 @@ variable "master_maintenance_window" {
   })
   default = {
     day          = 1 # Monday
-    hour         = 9 # UTC
+    hour         = 8 # UTC
     update_track = "stable"
   }
 


### PR DESCRIPTION
Summary
Add support for setting a maintenance window for GCP PostgreSQL instances.

Why
To avoid unexpected downtime during peak hours by defining when automatic maintenance can occur.

What
Added maintenanceWindow config to the PostgreSQL Terraform module.
Updated docs and set safe defaults.

Solution
Used GCP’s native maintenance_window block to allow configurable, predictable maintenance timing.

## Types of Changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply --->
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 🚀 New feature (non-breaking change which adds functionality)
- [ ] 🕷 Bug fix (non-breaking change which fixes an issue)
- [x] 👏 Performance optimization (non-breaking change which addresses a performance issue)
- [ ] 🛠 Refactor (non-breaking change which does not change existing behavior or add new functionality)
- [ ] 📗 Library update (non-breaking change that will update one or more libraries to newer versions)
- [ ] 📝 Documentation (non-breaking change that doesn't change code behavior, can skip testing)
- [ ] ✅ Test (non-breaking change related to testing)
- [ ] 🔒 Security awareness (changes that effect permission scope, security scenarios)

## Test Plan
<!--- Please input steps on how to test this PR, including evidence in the form of captured images or videos. If this is not necessary, provide the reason why. --->
Verify at DB maintenance config

## Related Issues
<!--- Add a reference section for management tickets, and relevant conversations. --->
