### PR TITLE
chore(release): 0.6.8 - helm-argocd notifications + route53 fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.6.8]() (2026-07-10)
+
+### Fix Bugs
+
+* AWS Helm-ArgoCD [(./aws/helm-argocd)](./aws/helm-argocd)
+    * Default notifications subscription now references trigger names (`on-deployed`, `on-sync-failed`, `on-sync-running`, `on-sync-succeeded`) instead of template names, so the global `slack:social` subscription actually fires on deploy/sync events.
+    * Correct the `route53` submodule source path (`../route53`) broken by the module flatten.
+
 ## [0.6.7]() (2025-06-10)
 
 ### Features


### PR DESCRIPTION
Cuts repo release tag `v0.6.8` so consumers can pin `github.com/spartan-stratos/terraform-modules//aws/helm-argocd?ref=v0.6.8` with the merged fix from #431 (default notifications subscription trigger names + route53 submodule path).

The registry publish path (`terraform.c0x12c.com`) is currently disabled, so consumers move to the git-ref source (the dominant sourcing pattern in-repo). Merging this to master triggers the active `Release` workflow, which extracts `0.6.8` from CHANGELOG.md and cuts `v0.6.8`.

CHANGELOG-only change.